### PR TITLE
modules : hal : microchip Add remaining MEC1501 HAL headers

### DIFF
--- a/mec/common/mec_cpu.h
+++ b/mec/common/mec_cpu.h
@@ -283,6 +283,10 @@ static __always_inline void write_read_back32(volatile uint32_t* addr, uint32_t 
 
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* #ifndef _CPU_H */
 /**   @}
  */

--- a/mec/mec1501/MEC1501hsz.h
+++ b/mec/mec1501/MEC1501hsz.h
@@ -431,6 +431,7 @@ typedef enum IRQn {
 /** @} *//* End of group Device_Peripheral_peripheralAddr */
 
 #include "component/acpi_ec.h"
+#include "component/adc.h"
 #include "component/dma.h"
 #include "component/ecia.h"
 #include "component/ecs.h"
@@ -440,16 +441,24 @@ typedef enum IRQn {
 #include "component/espi_mem.h"
 #include "component/espi_vw.h"
 #include "component/global_cfg.h"
+#include "component/hdmi_cec.h"
 #include "component/i2c.h"
 #include "component/kbc.h"
 #include "component/keyscan.h"
 #include "component/led.h"
 #include "component/mailbox.h"
 #include "component/pcr.h"
+#include "component/peci.h"
 #include "component/port80cap.h"
 #include "component/port92.h"
+#include "component/prochot.h"
 #include "component/ps2_ctrl.h"
+#include "component/pwm.h"
+#include "component/qmspi.h"
+#include "component/rtc.h"
 #include "component/smb.h"
+#include "component/spi_slave.h"
+#include "component/tach.h"
 #include "component/tfdp.h"
 #include "component/timer.h"
 #include "component/uart.h"
@@ -486,13 +495,38 @@ typedef enum IRQn {
 #define DMA10_REGS      ((DMA_CHAN_Type *)(DMA_CHAN_BASE(10)))
 #define DMA11_REGS      ((DMA_CHAN_Type *)(DMA_CHAN_BASE(11)))
 
+#define PROCHOT_REGS	((PROCHOT_Type *) PROCHOT_BASE)
+
 #define SMB0_REGS       ((I2C_SMB_Type *) SMB0_BASE)
 #define SMB1_REGS       ((I2C_SMB_Type *) SMB1_BASE)
 #define SMB2_REGS       ((I2C_SMB_Type *) SMB2_BASE)
 #define SMB3_REGS       ((I2C_SMB_Type *) SMB3_BASE)
 #define SMB4_REGS       ((I2C_SMB_Type *) SMB4_BASE)
 
+#define PWM0_REGS	((PWM_Type *) PWM0_BASE)
+#define PWM1_REGS	((PWM_Type *) PWM1_BASE)
+#define PWM2_REGS	((PWM_Type *) PWM2_BASE)
+#define PWM3_REGS	((PWM_Type *) PWM3_BASE)
+#define PWM4_REGS	((PWM_Type *) PWM4_BASE)
+#define PWM5_REGS	((PWM_Type *) PWM5_BASE)
+#define PWM6_REGS	((PWM_Type *) PWM6_BASE)
+#define PWM7_REGS	((PWM_Type *) PWM7_BASE)
+#define PWM8_REGS	((PWM_Type *) PWM8_BASE)
+
+#define TACH0_REGS	((TACH_Type *) TACH0_BASE)
+#define TACH1_REGS	((TACH_Type *) TACH1_BASE)
+#define TACH2_REGS	((TACH_Type *) TACH2_BASE)
+#define TACH3_REGS	((TACH_Type *) TACH3_BASE)
+
+#define PECI_REGS	((PECI_Type *) PECI_BASE)
+
+#define HDMI_CEC_REGS	((HDMI_CEC_Type *) HDMI_CEC_BASE)
+
+#define SPISLV_REGS	((SPISLV_Type *) SPISLV_BASE)
+
 #define RTMR_REGS       ((RTMR_Type *) RTMR_BASE)
+
+#define ADC_REGS	((ADC_Type *) ADC_BASE)
 
 #define TFDP_REGS	((TFDP_Type *) TFDP_BASE)
 
@@ -507,6 +541,8 @@ typedef enum IRQn {
 #define VBATR_REGS      ((VBATR_Type *) VBATR_BASE)
 #define VBATM_REGS      ((VBATM_Type *) VBATM_BASE)
 #define WKTMR_REGS      ((WKTMR_Type *) WKTMR_BASE)
+
+#define VCI_REGS	((VCI_Type *) VCI_BASE)
 
 #define LED0_REGS       ((LED_Type *) LED0_BASE)
 #define LED1_REGS       ((LED_Type *) LED1_BASE)
@@ -554,6 +590,8 @@ typedef enum IRQn {
 #define ACPI_EC_2_REGS  ((ACPI_EC_Type *)(ACPI_EC_2_BASE))
 #define ACPI_EC_3_REGS  ((ACPI_EC_Type *)(ACPI_EC_3_BASE))
 
+#define ACPI_PM1_REGS	((ACPI_PM1_Type *) ACPI_PM1_BASE)
+
 #define PORT92_REGS     ((PORT92_Type *)(PORT92_BASE))
 
 #define UART0_REGS      ((UART_Type *) UART0_BASE)
@@ -585,6 +623,8 @@ typedef enum IRQn {
 
 #define EMI0_REGS       ((EMI_Type *)(EMI0_BASE))
 #define EMI1_REGS       ((EMI_Type *)(EMI0_BASE))
+
+#define RTC_REGS	((RTC_Type *) RTC_BASE)
 
 #define PORT80_CAP0_REGS	((PORT80_CAP_Type *)(P80CAP0_BASE))
 #define PORT80_CAP1_REGS	((PORT80_CAP_Type *)(P80CAP1_BASE))

--- a/mec/mec1501/component/acpi_ec.h
+++ b/mec/mec1501/component/acpi_ec.h
@@ -39,7 +39,7 @@
 #include "regaccess.h"
 
 /* =========================================================================*/
-/* ================   ACPI_EC				   ================ */
+/* ================		 ACPI_EC 		=================== */
 /* =========================================================================*/
 
 #define MCHP_ACPI_EC_BASE_ADDR		0x400F0800ul
@@ -129,8 +129,7 @@
 /**
   * @brief ACPI EC Registers (ACPI_EC)
   */
-typedef struct acpi_ec_regs
- {
+typedef struct acpi_ec_regs {
 	__IOM uint32_t OS_DATA;		/*!< (@ 0x0000) OS Data */
 	__IOM uint8_t OS_CMD_STS;	/*!< (@ 0x0004) OS Command(WO), Status(RO) */
 	__IOM uint8_t OS_BYTE_CTRL;	/*!< (@ 0x0005) OS Byte Control */
@@ -141,6 +140,121 @@ typedef struct acpi_ec_regs
 	uint8_t RSVD2[2];
 	__IOM uint32_t OS2EC_DATA;	/*!< (@ 0x0108) OS to EC Data */
 } ACPI_EC_Type;
+
+/* =========================================================================*/
+/* ================		 ACPI_PM1 		=================== */
+/* =========================================================================*/
+
+#define MCHP_ACPI_PM1_BASE_ADDR		0x400F1C00ul
+
+/*
+ * ACPI_PM1 interrupts
+ */
+#define MCHP_ACPI_PM1_CTL_GIRQ	15u
+#define MCHP_ACPI_PM1_EN_GIRQ	15u
+#define MCHP_ACPI_PM1_STS_GIRQ	15u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_ACPI_PM1_CTL_GIRQ_POS	15u
+#define MCHP_ACPI_PM1_EN_GIRQ_POS	16u
+#define MCHP_ACPI_PM1_STS_GIRQ_POS	17u
+
+#define MCHP_ACPI_PM1_CTL_GIRQ_VAL	(1ul << MCHP_ACPI_PM1_CTL_GIRQ_POS)
+#define MCHP_ACPI_PM1_EN_GIRQ_VAL	(1ul << MCHP_ACPI_PM1_EN_GIRQ_POS)
+#define MCHP_ACPI_PM1_STS_GIRQ_VAL	(1ul << MCHP_ACPI_PM1_STS_GIRQ_POS)
+
+/* VCI GIRQ aggregated NVIC input */
+#define MCHP_ACPI_PM1_CTL_NVIC_AGGR	7u
+#define MCHP_ACPI_PM1_EN_NVIC_AGGR	7u
+#define MCHP_ACPI_PM1_STS_NVIC_AGGR	7u
+
+/* VCI direct NVIC inputs */
+#define MCHP_ACPI_PM1_CTL_NVIC_DIRECT	55u
+#define MCHP_ACPI_PM1_EN_NVIC_DIRECT	56u
+#define MCHP_ACPI_PM1_STS_NVIC_DIRECT	57u
+
+/* ACPI_PM1 RT/EC Status 1 */
+#define MCHP_ACPI_PM1_RT_STS1_REG_OFS		0x0000ul
+#define MCHP_ACPI_PM1_EC_STS1_REG_OFS		0x0100ul
+#define MCHP_ACPI_PM1_STS1_REG_MASK		0x0000ul
+
+/* ACPI_PM1 RT/EC Status 2 */
+#define MCHP_ACPI_PM1_RT_STS2_REG_OFS		0x0001ul
+#define MCHP_ACPI_PM1_EC_STS2_REG_OFS		0x0101ul
+#define MCHP_ACPI_PM1_STS2_REG_MASK		0x008Ful
+#define MCHP_ACPI_PM1_STS2_PWRBTN		(1ul << 0)
+#define MCHP_ACPI_PM1_STS2_SLPBTN		(1ul << 1)
+#define MCHP_ACPI_PM1_STS2_RTC			(1ul << 2)
+#define MCHP_ACPI_PM1_STS2_PWRBTNOR		(1ul << 3)
+#define MCHP_ACPI_PM1_STS2_WAK			(1ul << 7)
+
+/* ACPI_PM1 RT/EC Enable 1 */
+#define MCHP_ACPI_PM1_RT_EN1_REG_OFS		0x0002ul
+#define MCHP_ACPI_PM1_EC_EN1_REG_OFS		0x0102ul
+#define MCHP_ACPI_PM1_EN1_REG_MASK		0x0000ul
+
+/* ACPI_PM1 RT/EC Enable 2 */
+#define MCHP_ACPI_PM1_RT_EN2_REG_OFS		0x0003ul
+#define MCHP_ACPI_PM1_EC_EN2_REG_OFS		0x0103ul
+#define MCHP_ACPI_PM1_EN2_REG_MASK		0x0007ul
+#define MCHP_ACPI_PM1_EN2_PWRBTN		(1ul << 0)
+#define MCHP_ACPI_PM1_EN2_SLPBTN		(1ul << 1)
+#define MCHP_ACPI_PM1_EN2_RTC			(1ul << 2)
+
+/* ACPI_PM1 RT/EC Control 1 */
+#define MCHP_ACPI_PM1_RT_CTRL1_REG_OFS		0x0004ul
+#define MCHP_ACPI_PM1_EC_CTRL1_REG_OFS		0x0104ul
+#define MCHP_ACPI_PM1_CTRL1_REG_MASK		0x0000ul
+
+/* ACPI_PM1 RT/EC Control 2 */
+#define MCHP_ACPI_PM1_RT_CTRL2_REG_OFS		0x0005ul
+#define MCHP_ACPI_PM1_EC_CTRL2_REG_OFS		0x0105ul
+#define MCHP_ACPI_PM1_CTRL2_REG_MASK		0x003Eul
+#define MCHP_ACPI_PM1_CTRL2_PWRBTNOR_EN		(1ul << 1)
+#define MCHP_ACPI_PM1_CTRL2_SLP_TYPE_POS	2
+#define MCHP_ACPI_PM1_CTRL2_SLP_TYPE_MASK	(0x03ul << 2)
+#define MCHP_ACPI_PM1_CTRL2_SLP_EN		(1ul << 5)
+
+/* ACPI_PM1 RT/EC Control 21 */
+#define MCHP_ACPI_PM1_RT_CTRL21_REG_OFS		0x0006ul
+#define MCHP_ACPI_PM1_EC_CTRL21_REG_OFS		0x0106ul
+#define MCHP_ACPI_PM1_CTRL21_REG_MASK		0x0000ul
+
+/* ACPI_PM1 RT/EC Control 22 */
+#define MCHP_ACPI_PM1_RT_CTRL22_REG_OFS		0x0007ul
+#define MCHP_ACPI_PM1_EC_CTRL22_REG_OFS		0x0107ul
+#define MCHP_ACPI_PM1_CTRL22_REG_MASK		0x0000ul
+
+/* ACPI_PM1 EC PM Status register */
+#define MCHP_ACPI_PM1_EC_PM_STS_REG_OFS		0x0110ul
+#define MCHP_ACPI_PM1_EC_PM_STS_REG_MASK	0x0001ul
+#define MCHP_ACPI_PM1_EC_PM_STS_SCI		0x0001ul
+
+/**
+  * @brief ACPI PM1 Registers (ACPI_PM1)
+  */
+typedef struct acpi_pm1_regs {
+	__IOM uint8_t  RT_STS1; /*!< (@ 0x0000) */
+	__IOM uint8_t  RT_STS2; /*!< (@ 0x0001) */
+	__IOM uint8_t  RT_EN1; /*!< (@ 0x0002) */
+	__IOM uint8_t  RT_EN2; /*!< (@ 0x0003) */
+	__IOM uint8_t  RT_CTRL1; /*!< (@ 0x0004) */
+	__IOM uint8_t  RT_CTRL2; /*!< (@ 0x0005) */
+	__IOM uint8_t  RT_CTRL21; /*!< (@ 0x0006) */
+	__IOM uint8_t  RT_CTRL22; /*!< (@ 0x0007) */
+	uint8_t RSVD1[(0x100u - 0x008u)];
+	__IOM uint8_t  EC_STS1; /*!< (@ 0x0100) */
+	__IOM uint8_t  EC_STS2; /*!< (@ 0x0101) */
+	__IOM uint8_t  EC_EN1; /*!< (@ 0x0102) */
+	__IOM uint8_t  EC_EN2; /*!< (@ 0x0103) */
+	__IOM uint8_t  EC_CTRL1; /*!< (@ 0x0104) */
+	__IOM uint8_t  EC_CTRL2; /*!< (@ 0x0105) */
+	__IOM uint8_t  EC_CTRL21; /*!< (@ 0x0106) */
+	__IOM uint8_t  EC_CTRL22; /*!< (@ 0x0107) */
+	uint8_t RSVD2[(0x0110u - 0x0108u)];
+	__IOM uint8_t  EC_PM_STS; /*!< (@ 0x0110) */
+	uint8_t RSVD3[3];
+} ACPI_PM1_Type;
 
 #endif	/* #ifndef _ACPI_EC_H */
 /* end acpi_ec.h */

--- a/mec/mec1501/component/adc.h
+++ b/mec/mec1501/component/adc.h
@@ -1,0 +1,194 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file peci.h
+ *MEC1501 Analog to Digital Converter registers
+ */
+/** @defgroup MEC1501 Peripherals ADC
+ */
+
+#ifndef _ADC_H
+#define _ADC_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 ADC 				=========== */
+/* =========================================================================*/
+
+#define MCHP_ADC_BASE_ADDR	0x40007C00ul
+
+/*
+ * ADC block implements two interrupt signals:
+ * single conversion and repeat conversion done.
+ */
+#define MCHP_ADC_GIRQ		17u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_ADC_SNG_DONE_GIRQ_POS	8
+#define MCHP_ADC_RPT_DONE_GIRQ_POS	9
+
+#define MCHP_ADC_SNG_DONE_GIRQ_VAL	(1ul << MCHP_ADC_SNG_DONE_GIRQ_POS)
+#define MCHP_ADC_RPT_DONE_GIRQ_VAL	(1ul << MCHP_ADC_RPT_DONE_GIRQ_POS)
+
+/* ADC GIRQ aggregated NVIC input */
+#define MCHP_ADC_SNG_DONE_NVIC_AGGR	9u
+#define MCHP_ADC_RPT_DONE_NVIC_AGGR	9u
+
+/* ADC direct NVIC inputs */
+#define MCHP_ADC_SNG_DONE_NVIC_DIRECT	78u
+#define MCHP_ADC_RPT_DONE_NVIC_DIRECT	79u
+
+/* Eight ADC channels numbered 0 - 7 */
+#define MCHP_ADC_MAX_CHAN		8
+#define MCHP_ADC_MAX_CHAN_MASK		0x07u
+
+/* Control register */
+#define MCHP_ADC_CTRL_REG_OFS		0
+
+/* Delay register */
+#define MCHP_ADC_DELAY_REG_OFS		4
+
+/* Status register */
+#define MCHP_ADC_STATUS_REG_OFS		8
+
+/* Single Conversion Select register */
+#define MCHP_ADC_SCS_REG_OFS		0x0C
+#define MCHP_ADC_SCS_REG_MASK		0xffu
+#define MCHP_ADC_SCS_CH_0_7		0xffu
+#define MCHP_ADC_SCS_CH(n)	(1ul << ((n) & 0x07))
+
+/* Repeat Conversion Select register */
+#define MCHP_ADC_RCS_REG_OFS		0x10
+#define MCHP_ADC_RCS_REG_MASK		0xffu
+#define MCHP_ADC_RCS_CH_0_7		0xffu
+#define MCHP_ADC_RCS_CH(n)	(1ul << ((n) & 0x07))
+
+/* Channel reading registers */
+#define MCHP_ADC_RDCH_REG_MASK		0xFFFul
+#define MCHP_ADC_RDCH0_REG_OFS		0x14
+#define MCHP_ADC_RDCH1_REG_OFS		0x18
+#define MCHP_ADC_RDCH2_REG_OFS		0x1C
+#define MCHP_ADC_RDCH3_REG_OFS		0x20
+#define MCHP_ADC_RDCH4_REG_OFS		0x24
+#define MCHP_ADC_RDCH5_REG_OFS		0x28
+#define MCHP_ADC_RDCH6_REG_OFS		0x2C
+#define MCHP_ADC_RDCH7_REG_OFS		0x30
+
+/* Configuration register */
+#define MCHP_ADC_CFG_REG_OFS		0x7Cu
+#define MCHP_ADC_CFG_REG_MASK		0xffffu
+#define MCHP_ADC_CFG_CLK_LO_TIME_POS	0
+#define MCHP_ADC_CFG_CLK_LO_TIME_MASK0	0xffu
+#define MCHP_ADC_CFG_CLK_LO_TIME_MASK	0xffu
+#define MCHP_ADC_CFG_CLK_HI_TIME_POS	8
+#define MCHP_ADC_CFG_CLK_HI_TIME_MASK0	0xffu
+#define MCHP_ADC_CFG_CLK_HI_TIME_MASK	(0xfful << 8)
+
+/* Channel Vref Select register */
+#define MCHP_ADC_CH_VREF_SEL_REG_OFS	0x80u
+#define MCHP_ADC_CH_VREF_SEL_REG_MASK	0x00fffffful
+#define MCHP_ADC_CH_VREF_SEL_MASK(n)	(0x03ul << (((n) & 0x07) << 1))
+#define MCHP_ADC_CH_VREF_SEL_PAD(n)	(0x00ul << (((n) & 0x07) << 1))
+#define MCHP_ADC_CH_VREF_SEL_GPIO(n)	(0x01ul << (((n) & 0x07) << 1))
+
+/* Vref Control register */
+#define MCHP_ADC_VREF_CTRL_REG_OFS		0x84u
+#define MCHP_ADC_VREF_CTRL_REG_MASK		0xffffffffu
+#define MCHP_ADC_VREF_CTRL_CHRG_DEL_POS		0
+#define MCHP_ADC_VREF_CTRL_CHRG_DEL_MASK0	0xffffu
+#define MCHP_ADC_VREF_CTRL_CHRG_DEL_MASK	0xffffu
+#define MCHP_ADC_VREF_CTRL_SW_DEL_POS		16
+#define MCHP_ADC_VREF_CTRL_SW_DEL_MASK0		0x1fffu
+#define MCHP_ADC_VREF_CTRL_SW_DEL_MASK		(0x1ffful << 16)
+#define MCHP_ADC_VREF_CTRL_PAD_POS		29
+#define MCHP_ADC_VREF_CTRL_PAD_UNUSED_FLOAT	(0ul << 29)
+#define MCHP_ADC_VREF_CTRL_PAD_UNUSED_DRIVE_LO	(1ul << 29)
+#define MCHP_ADC_VREF_CTRL_SEL_STS_POS		30
+#define MCHP_ADC_VREF_CTRL_SEL_STS_MASK0	0x03u
+#define MCHP_ADC_VREF_CTRL_SEL_STS_MASK		(0x03ul << 30)
+
+/* SAR ADC Control register */
+#define MCHP_ADC_SAR_CTRL_REG_OFS	0x88u
+#define MCHP_ADC_SAR_CTRL_REG_MASK	0x0001FF8Ful
+/* Select single ended or differential operation */
+#define MCHP_ADC_SAR_CTRL_SELDIFF_POS	0
+#define MCHP_ADC_SAR_CTRL_SELDIFF_DIS	(0ul << 0)
+#define MCHP_ADC_SAR_CTRL_SELDIFF_EN	(1ul << 0)
+/* Select resolution */
+#define MCHP_ADC_SAR_CTRL_RES_POS	1
+#define MCHP_ADC_SAR_CTRL_RES_MASK0	0x03u
+#define MCHP_ADC_SAR_CTRL_RES_MASK	(0x03ul << 1)
+#define MCHP_ADC_SAR_CTRL_RES_10_BITS	(0x01ul << 1)
+#define MCHP_ADC_SAR_CTRL_RES_12_BITS	(0x03ul << 1)
+/* Shift data in reading register */
+#define MCHP_ADC_SAR_CTRL_SHIFTD_POS	3
+#define MCHP_ADC_SAR_CTRL_SHIFTD_DIS	(0ul << 3)
+#define MCHP_ADC_SAR_CTRL_SHIFTD_EN	(1ul << 3)
+/* Warm up delay in ADC clock cycles */
+#define MCHP_ADC_SAR_CTRL_WUP_DLY_POS	7
+#define MCHP_ADC_SAR_CTRL_WUP_DLY_MASK0	0x3fful
+#define MCHP_ADC_SAR_CTRL_WUP_DLY_MASK	(0x3fful << 7)
+#define MCHP_ADC_SAR_CTRL_WUP_DLY_DFLT	(0x202ul << 7)
+
+/* Register interface */
+#define MCHP_ADC_CH_NUM(n) ((n) & MCHP_ADC_MAX_CHAN_MASK)
+#define MCHP_ADC_CH_OFS(n) (MCHP_ADC_CH_NUM(n) << 2)
+#define MCHP_ADC_CH_ADDR(n) (MCHP_ADC_BASE_ADDR + MCHP_ADC_CH_OFS(n))
+
+#define MCHP_ADC_RD_CHAN(n) REG32(MCHP_ADC_CH_ADDR(n))
+
+/**
+  * @brief Analog to Digital Converter Registers (ADC)
+  */
+typedef struct adc_regs {
+	__IOM uint32_t CONTROL; /*!< (@ 0x0000) ADC Control */
+	__IOM uint32_t DELAY; /*!< (@ 0x0004) ADC Delay */
+	__IOM uint32_t STATUS; /*!< (@ 0x0008) ADC Status */
+	__IOM uint32_t SINGLE; /*!< (@ 0x000C) ADC Single */
+	__IOM uint32_t REPEAT; /*!< (@ 0x0010) ADC Repeat */
+	__IOM uint32_t RDCH0; /*!< (@ 0x0014) ADC Chan0 Reading */
+	__IOM uint32_t RDCH1; /*!< (@ 0x0018) ADC Chan1 Reading */
+	__IOM uint32_t RDCH2; /*!< (@ 0x001C) ADC Chan2 Reading */
+	__IOM uint32_t RDCH3; /*!< (@ 0x0020) ADC Chan3 Reading */
+	__IOM uint32_t RDCH4; /*!< (@ 0x0024) ADC Chan4 Reading */
+	__IOM uint32_t RDCH5; /*!< (@ 0x0028) ADC Chan5 Reading */
+	__IOM uint32_t RDCH6; /*!< (@ 0x002C) ADC Chan6 Reading */
+	__IOM uint32_t RDCH7; /*!< (@ 0x0030) ADC Chan7 Reading */
+	uint8_t RSVD1[0x7C - 0x34];
+	__IOM uint32_t CONFIG; /*!< (@ 0x007C) ADC Configuration */
+	__IOM uint32_t VREF_CHAN_SEL; /*!< (@ 0x0080) ADC Vref Channel Sel. */
+	__IOM uint32_t VREF_CTRL; /*!< (@ 0x0084) ADC Vref Control */
+	__IOM uint32_t SARADC_CTRL; /*!< (@ 0x0088) SAR ARD Control */
+} ADC_Type;
+
+#endif	/* #ifndef _ADC_H */
+/* end adc.h */
+/**   @}
+ */

--- a/mec/mec1501/component/ecia.h
+++ b/mec/mec1501/component/ecia.h
@@ -145,6 +145,9 @@
 	(MCHP_ECIA_ADDR + MCHP_ECIA_BLK_ACTIVE_OFS)
 
 /* 8 <= n <= 26 */
+#define MCHP_GIRQ_TO_AGGR_NVIC(n) (((n) < 23) ? ((n)-8) : ((n)-9))
+
+/* 8 <= n <= 26 */
 #define MCHP_GIRQ_SRC_ADDR(n) \
 	((MCHP_ECIA_ADDR + 0x00ul) + (((uint32_t)(n) - 8ul) * 0x14ul))
 

--- a/mec/mec1501/component/ecs.h
+++ b/mec/mec1501/component/ecs.h
@@ -176,18 +176,18 @@ typedef struct ecs_regs
 	__IOM uint32_t JTAG_MTMS;	/*!< (@ 0x0080) ECS JTAG Master TMS */
 	__IOM uint32_t JTAG_MCMD;	/*!< (@ 0x0084) ECS JTAG Master Command */
 	uint8_t RSVD3[8];
-	__IOM uint32_t VW_FW_OVR;	/*!< (@ 0x0090) ECS VWire FW Override */
+	__IOM uint32_t VW_FW_OVR;	/*!< (@ 0x0090) ECS VWire Source Config */
 	__IOM uint32_t CMP_CTRL;	/*!< (@ 0x0094) ECS Analog Comparator Control */
 	__IOM uint32_t CMP_SLP_CTRL;	/*!< (@ 0x0098) ECS Analog Comparator Sleep Control */
 	uint8_t RSVD4[(0xF0 - 0x9C)];
 	__IOM uint32_t IP_TRIM;	/*!< (@ 0x00F0) ECS IP Trim */
-	uint8_t RSVD5[12];
-	__IOM uint32_t TEST100;
-	uint8_t RSVD6[(0x180 - 0x94)];
-	__IOM uint32_t FW_SCR0;	/*!< (@ 0x0180) ECS FW Scratch 0 */
-	__IOM uint32_t FW_SCR1;	/*!< (@ 0x0180) ECS FW Scratch 1 */
-	__IOM uint32_t FW_SCR2;	/*!< (@ 0x0180) ECS FW Scratch 2 */
-	__IOM uint32_t FW_SCR3;	/*!< (@ 0x0180) ECS FW Scratch 3 */
+	uint8_t RSVD5[(0x144 - 0xF4)];
+	__IOM uint32_t SLP_STS_MIRROR; /*!< (@ 0x0144) ECS Sleep Status Mirror (RO) */
+	uint8_t RSVD6[(0x180 - 0x148)];
+	__IOM uint32_t BROM_SCR0;	/*!< (@ 0x0180) ECS Boot-ROM Scratch 0 */
+	__IOM uint32_t BROM_SCR1;	/*!< (@ 0x0180) ECS Boot-ROM Scratch 1 */
+	__IOM uint32_t BROM_SCR2;	/*!< (@ 0x0180) ECS Boot-ROM Scratch 2 */
+	__IOM uint32_t BROM_SCR3;	/*!< (@ 0x0180) ECS Boot-ROM Scratch 3 */
 } ECS_Type;
 
 #endif				// #ifndef _ECS_H

--- a/mec/mec1501/component/hdmi_cec.h
+++ b/mec/mec1501/component/hdmi_cec.h
@@ -1,0 +1,157 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file hdmi_cec.h
+ *MEC1501 HDMI CEC registers
+ */
+/** @defgroup MEC1501 Peripherals HDMI-CEC
+ */
+
+#ifndef _HDMI_CEC_H
+#define _HDMI_CEC_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 HDMI CEC 			=========== */
+/* =========================================================================*/
+
+#define MCHP_HDMI_CEC_BASE_ADDR		0x40006800ul
+
+/*
+ * HDMI_CEC interrupts
+ */
+#define MCHP_HDMI_CEC_GIRQ	17u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_HDMI_CEC_GIRQ_POS	5u
+
+#define MCHP_HDMI_CEC_GIRQ_VAL	(1ul << MCHP_HDMI_CEC_GIRQ_POS)
+
+/* HDMI_CEC GIRQ aggregated NVIC input */
+#define MCHP_HDMI_CEC_NVIC_AGGR	9u
+
+/* HDMI_CEC direct NVIC inputs */
+#define MCHP_HDMI_CEC_NVIC_DIRECT	160u
+
+/* HDMI_CEC Control register */
+#define MCHP_HDMI_CEC_CTRL_REG_OFS	0U
+#define MCHP_HDMI_CEC_CTRL_MASK		0x0Fu
+#define MCHP_HDMI_CEC_CTRL_ACT_POS	0
+#define MCHP_HDMI_CEC_CTRL_ACT		(1ul << 0)
+#define MCHP_HDMI_CEC_CTRL_RST_POS	1
+#define MCHP_HDMI_CEC_CTRL_RST		(1ul << 1)
+#define MCHP_HDMI_CEC_CTRL_FILT_EN_POS	2
+#define MCHP_HDMI_CEC_CTRL_FILT_EN	(1ul << 2)
+#define MCHP_HDMI_CEC_CTRL_SFT5_POS	3
+#define MCHP_HDMI_CEC_CTRL_SFT5_EN	(1ul << 3)
+
+/* HDMI_CEC Claimed Logic Address register  */
+#define MCHP_HDMI_CEC_CLA_REG_OFS	4U
+#define MCHP_HDMI_CEC_CLA_MASK		0xFFFFu
+
+/* HDMI_CEC Initiator Data Register */
+#define MCHP_HDMI_CEC_IDATA_REG_OFS	8U
+#define MCHP_HDMI_CEC_IDATA_REG_MASK	0x01ffU
+#define MCHP_HDMI_CEC_IDATA_POS		0
+#define MCHP_HDMI_CEC_IDATA_MASK	0xffU
+#define MCHP_HDMI_CEC_IDATA_EOM_POS	8
+#define MCHP_HDMI_CEC_IDATA_EOM		(1ul << 8)
+
+/* HDMI_CEC Follower Data Register  */
+#define MCHP_HDMI_CEC_FDATA_REG_OFS	0x0CU
+#define MCHP_HDMI_CEC_FDATA_REG_MASK	0x01ffU
+#define MCHP_HDMI_CEC_FDATA_POS		0
+#define MCHP_HDMI_CEC_FDATA_MASK	0xffU
+#define MCHP_HDMI_CEC_FDATA_EOM_POS	8
+#define MCHP_HDMI_CEC_FDATA_EOM		(1ul << 8)
+
+/* HDMI_CEC Initiator/Follower Status Register */
+#define MCHP_HDMI_CEC_IFSTS_REG_OFS	0x10U
+#define MCHP_HDMI_CEC_IFSTS_REG_MASK	0x007F007Fu
+#define MCHP_HDMI_CEC_ISTS_POS		0
+#define MCHP_HDMI_CEC_ISTS_IDLE		(1ul << 0)
+#define MCHP_HDMI_CEC_ISTS_LAB		(1ul << 1)
+#define MCHP_HDMI_CEC_ISTS_UNDRN	(1ul << 2)
+#define MCHP_HDMI_CEC_ISTS_ACKERR	(1ul << 3)
+#define MCHP_HDMI_CEC_ISTS_CE		(1ul << 4)
+#define MCHP_HDMI_CEC_ISTS_IFE		(1ul << 5)
+#define MCHP_HDMI_CEC_ISTS_IFDONE	(1ul << 6)
+/* follower status */
+#define MCHP_HDMI_CEC_FSTS_POS		16
+#define MCHP_HDMI_CEC_FSTS_OVRN		(1ul << 16)
+#define MCHP_HDMI_CEC_FSTS_BERR		(1ul << 17)
+#define MCHP_HDMI_CEC_FSTS_BTO		(1ul << 18)
+#define MCHP_HDMI_CEC_FSTS_FFNE		(1ul << 19)
+#define MCHP_HDMI_CEC_FSTS_FFF		(1ul << 20)
+#define MCHP_HDMI_CEC_FSTS_FDR		(1ul << 21)
+#define MCHP_HDMI_CEC_FSTS_FFDONE	(1ul << 22)
+
+/* HDMI_CEC Initiator Control Register */
+#define MCHP_HDMI_CEC_ICTRL_REG_OFS		0x18u
+#define MCHP_HDMI_CEC_ICTRL_REG_MASK		0xE3u
+#define MCHP_HDMI_CEC_ICTRL_FLUSH_POS		0
+#define MCHP_HDMI_CEC_ICTRL_FLUSH		(1ul << 0)
+#define MCHP_HDMI_CEC_ICTRL_START_POS		1
+#define MCHP_HDMI_CEC_ICTRL_START		(1ul << 1)
+#define MCHP_HDMI_CEC_ICTRL_IFE_EN_POS		5
+#define MCHP_HDMI_CEC_ICTRL_IFE_EN		(1ul << 5)
+#define MCHP_HDMI_CEC_ICTRL_IFDONE_EN_POS	6
+#define MCHP_HDMI_CEC_ICTRL_IFDONE_EN		(1ul << 6)
+
+/* HDMI_CEC Follower Control Register */
+#define MCHP_HDMI_CEC_FCTRL_REG_OFS		0x1Cu
+#define MCHP_HDMI_CEC_FCTRL_REG_MASK		0x71u
+#define MCHP_HDMI_CEC_FCTRL_FLUSH_POS		0
+#define MCHP_HDMI_CEC_FCTRL_FLUSH		(1ul << 0)
+#define MCHP_HDMI_CEC_FCTRL_FFF_EN_POS		4
+#define MCHP_HDMI_CEC_FCTRL_FFF_EN		(1ul << 4)
+#define MCHP_HDMI_CEC_FCTRL_FDR_EN_POS		5
+#define MCHP_HDMI_CEC_FCTRL_FDR_EN		(1ul << 5)
+#define MCHP_HDMI_CEC_FCTRL_FFDONE_EN_POS	6
+#define MCHP_HDMI_CEC_FCTRL_FFDONE_EN		(1ul << 6)
+
+/**
+  * @brief HDMI CEC (HDMI_CEC)
+  */
+typedef struct hdmi_cec_regs {
+	__IOM uint32_t CEC_CONTROL; /*!< (@ 0x0000) HDMI_CEC Control */
+	__IOM uint32_t CL_ADDR; /*!< (@ 0x0004) HDMI_CEC Claimed Logic Address */
+	__IOM uint32_t IDATA; /*!< (@ 0x0008) HDMI_CEC Initiator Data */
+	__IOM uint32_t FDATA; /*!< (@ 0x000C) HDMI_CEC Follower Data */
+	__IOM uint32_t IFSTATUS; /*!< (@ 0x0010) HDMI_CEC Initiator/Follower Status */
+	uint8_t RSVD1[4];
+	__IOM uint32_t ICTRL; /*!< (@ 0x0018) HDMI_CEC Initiator Control */
+	__IOM uint32_t FCTRL; /*!< (@ 0x001C) HDMI_CEC Follower Control */
+} HDMI_CEC_Type;
+
+#endif	/* #ifndef _HDMI_CEC_H */
+/* end hdmi_cec.h */
+/**   @}
+ */

--- a/mec/mec1501/component/peci.h
+++ b/mec/mec1501/component/peci.h
@@ -1,0 +1,216 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file peci.h
+ *MEC1501 Platform Environment Control Interface registers
+ */
+/** @defgroup MEC1501 Peripherals PECI
+ */
+
+#ifndef _PECI_H
+#define _PECI_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 PECI 				=========== */
+/* =========================================================================*/
+
+#define MCHP_PECI_BASE_ADDR	0x40006400ul
+
+/*
+ * PECI interrupts.
+ */
+#define MCHP_PECI_GIRQ		17u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_PECI_GIRQ_POS	0
+
+#define MCHP_PECI_GIRQ_VAL	(1ul << MCHP_PECI_GIRQ_POS)
+
+/* PECI GIRQ aggregated NVIC input */
+#define MCHP_PECI_NVIC_AGGR	9u
+
+/* PECI direct NVIC inputs */
+#define MCHP_PECI_NVIC_DIRECT	70u
+
+/*
+ * Write Data register
+ */
+#define MCHP_PECI_WR_DATA_REG_OFS	0U
+#define MCHP_PECI_WR_DATA_MASK		0xffU
+
+/*
+ * Read Data register
+ */
+#define MCHP_PECI_RD_DATA_REG_OFS	4U
+#define MCHP_PECI_RD_DATA_MASK		0xffU
+
+/*
+ * Control register
+ */
+#define MCHP_PECI_CTRL_REG_OFS		8U
+#define MCHP_PECI_CTRL_MASK		0xE9U
+#define MCHP_PECI_CTRL_PD_POS		0
+#define MCHP_PECI_CTRL_PD		(1u << MCHP_PECI_CTRL_PD_POS)
+#define MCHP_PECI_CTRL_RST_POS		3
+#define MCHP_PECI_CTRL_RST		(1u << MCHP_PECI_CTRL_RST_POS)
+#define MCHP_PECI_CTRL_FRST_POS		5
+#define MCHP_PECI_CTRL_FRST		(1u << MCHP_PECI_CTRL_FRST_POS)
+#define MCHP_PECI_CTRL_TXEN_POS		6
+#define MCHP_PECI_CTRL_TXEN		(1u << MCHP_PECI_CTRL_TXEN_POS)
+#define MCHP_PECI_CTRL_MIEN_POS		7
+#define MCHP_PECI_CTRL_MIEN		(1u << MCHP_PECI_CTRL_MIEN_POS)
+
+/*
+ * Status 1 register. RW1C and read-only bits.
+ */
+#define MCHP_PECI_STS1_REG_OFS		0x0Cu
+#define MCHP_PECI_STS1_MASK		0xBFu
+#define MCHP_PECI_STS1_BOF_POS		0
+#define MCHP_PECI_STS1_BOF		(1u << MCHP_PECI_STS1_BOF_POS)
+#define MCHP_PECI_STS1_EOF_POS		1
+#define MCHP_PECI_STS1_EOF		(1u << MCHP_PECI_STS1_EOF_POS)
+/* Error is read-only */
+#define MCHP_PECI_STS1_ERR_POS		2
+#define MCHP_PECI_STS1_ERR		(1u << MCHP_PECI_STS1_ERR_POS)
+/* Ready is read-only */
+#define MCHP_PECI_STS1_RDY_POS		3
+#define MCHP_PECI_STS1_RDY		(1u << MCHP_PECI_STS1_RDY_POS)
+#define MCHP_PECI_STS1_RDYLO_POS	4
+#define MCHP_PECI_STS1_RDYLO		(1u << MCHP_PECI_STS1_RDYLO_POS)
+#define MCHP_PECI_STS1_RDYHI_POS	5
+#define MCHP_PECI_STS1_RDYHI		(1u << MCHP_PECI_STS1_RDYHI_POS)
+/* MINT is read-only */
+#define MCHP_PECI_STS1_MINT_POS		7
+#define MCHP_PECI_STS1_MINT		(1u << MCHP_PECI_STS1_MINT_POS)
+
+/*
+ * Status 2 register. Read-only bits.
+ */
+#define MCHP_PECI_STS2_REG_OFS		0x10u
+#define MCHP_PECI_STS2_MASK		0x8Fu
+#define MCHP_PECI_STS2_WFF_POS		0
+#define MCHP_PECI_STS2_WFF		(1u << MCHP_PECI_STS2_WFF_POS)
+#define MCHP_PECI_STS2_WFE_POS		1
+#define MCHP_PECI_STS2_WFE		(1u << MCHP_PECI_STS2_WFE_POS)
+#define MCHP_PECI_STS2_RFF_POS		2
+#define MCHP_PECI_STS2_RFF		(1u << MCHP_PECI_STS2_RFF_POS)
+#define MCHP_PECI_STS1_RFE_POS		3
+#define MCHP_PECI_STS1_RFE		(1u << MCHP_PECI_STS2_RFE_POS)
+#define MCHP_PECI_STS1_IDLE_POS		7
+#define MCHP_PECI_STS1_IDLE		(1u << MCHP_PECI_STS2_IDLE_POS)
+
+/*
+ * Error register. R/W1C bits.
+ */
+#define MCHP_PECI_ERR_REG_OFS		0x14u
+#define MCHP_PECI_ERR_MASK		0xF3u
+#define MCHP_PECI_ERR_FERR_POS		0
+#define MCHP_PECI_ERR_FERR		(1u << MCHP_PECI_ERR_FERR_POS)
+#define MCHP_PECI_ERR_BERR_POS		1
+#define MCHP_PECI_ERR_BERR		(1u << MCHP_PECI_ERR_BERR_POS)
+#define MCHP_PECI_ERR_WROV_POS		4
+#define MCHP_PECI_ERR_WROV		(1u << MCHP_PECI_ERR_WROV_POS)
+#define MCHP_PECI_ERR_WRUN_POS		5
+#define MCHP_PECI_ERR_WRUN		(1u << MCHP_PECI_ERR_WRUN_POS)
+#define MCHP_PECI_ERR_RDOV_POS		6
+#define MCHP_PECI_ERR_RDOV		(1u << MCHP_PECI_ERR_RDOV_POS)
+#define MCHP_PECI_ERR_CLK_POS		7
+#define MCHP_PECI_ERR_CLK		(1u << MCHP_PECI_ERR_CLK_POS)
+
+/*
+ * Interrupt Enable 1 register.
+ */
+#define MCHP_PECI_IEN1_REG_OFS		0x18u
+#define MCHP_PECI_IEN1_MASK		0x37u
+#define MCHP_PECI_IEN1_BIEN_POS		0
+#define MCHP_PECI_IEN1_BIEN		(1u << MCHP_PECI_IEN1_BIEN_POS)
+#define MCHP_PECI_IEN1_EIEN_POS		1
+#define MCHP_PECI_IEN1_EIEN		(1u << MCHP_PECI_IEN1_EIEN_POS)
+#define MCHP_PECI_IEN1_EREN_POS		2
+#define MCHP_PECI_IEN1_EREN		(1u << MCHP_PECI_IEN1_EREN_POS)
+#define MCHP_PECI_IEN1_RLEN_POS		4
+#define MCHP_PECI_IEN1_RLEN		(1u << MCHP_PECI_IEN1_RLEN_POS)
+#define MCHP_PECI_IEN1_RHEN_POS		5
+#define MCHP_PECI_IEN1_RHEN		(1u << MCHP_PECI_IEN1_RHEN_POS)
+
+/*
+ * Interrupt Enable 2 register.
+ */
+#define MCHP_PECI_IEN2_REG_OFS		0x1Cu
+#define MCHP_PECI_IEN2_MASK		0x06u
+#define MCHP_PECI_IEN2_ENWFE_POS	1
+#define MCHP_PECI_IEN2_ENWFE		(1u << MCHP_PECI_IEN2_ENWFE_POS)
+#define MCHP_PECI_IEN2_ENRFF_POS	2
+#define MCHP_PECI_IEN2_ENRFF		(1u << MCHP_PECI_IEN2_ENRFF_POS)
+
+/*
+ * Optimal Bit Time LSB register.
+ */
+#define MCHP_PECI_OPT_BT_LSB_REG_OFS	0x20u
+#define MCHP_PECI_OPT_BT_LSB_MASK	0xFFu
+
+/*
+ * Optimal Bit Time MSB register.
+ */
+#define MCHP_PECI_OPT_BT_MSB_REG_OFS	0x24u
+#define MCHP_PECI_OPT_BT_MSB_MASK	0xFFu
+
+
+/**
+  * @brief Platform Enviroment Control Interface Registers (PECI)
+  */
+typedef struct peci_regs {
+	__IOM uint8_t  WR_DATA; /*!< (@ 0x0000) PECI Write Data */
+	uint8_t RSVD1[3];
+	__IOM uint8_t  RD_DATA; /*!< (@ 0x0004) PECI Read data */
+	uint8_t RSVD2[3];
+	__IOM uint8_t  CONTROL;	/*!< (@ 0x0008) PECI Control */
+	uint8_t RSVD3[3];
+	__IOM uint8_t  STATUS1;	/*!< (@ 0x000C) PECI Status 1 */
+	uint8_t RSVD4[3];
+	__IOM uint8_t  STATUS2;	/*!< (@ 0x0010) PECI Status 2 */
+	uint8_t RSVD5[3];
+	__IOM uint8_t  ERROR;	/*!< (@ 0x0014) PECI Error */
+	uint8_t RSVD6[3];
+	__IOM uint8_t  INT_EN1;	/*!< (@ 0x0018) PECI Interrupt Enable 1 */
+	uint8_t RSVD7[3];
+	__IOM uint8_t  INT_EN2;	/*!< (@ 0x001C) PECI Interrupt Enable 2 */
+	uint8_t RSVD8[3];
+	__IOM uint8_t  OPT_BIT_TIME_LSB; /*!< (@ 0x0020) PECI Optimal Bit Time LSB */
+	uint8_t RSVD9[3];
+	__IOM uint8_t  OPT_BIT_TIME_MSB; /*!< (@ 0x0024) PECI Optimal Bit Time MSB */
+	uint8_t RSVD10[87]; /* 0x25 - 0x7C */
+} PECI_Type;
+
+#endif	/* #ifndef _PECI_H */
+/* end peci.h */
+/**   @}
+ */

--- a/mec/mec1501/component/prochot.h
+++ b/mec/mec1501/component/prochot.h
@@ -1,0 +1,114 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file prochot.h
+ *MEC1501 Processor temperature control registers
+ */
+/** @defgroup MEC1501 Peripherals PROCHOT
+ */
+
+#ifndef _PROCHOT_H
+#define _PROCHOT_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 PROCHOT 			=========== */
+/* =========================================================================*/
+
+#define MCHP_PROCHOT_BASE_ADDR	0x40003400ul
+
+/*
+ * PROCHOT interrupt signal:
+ */
+#define MCHP_PROCHOT_GIRQ		17u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_PROCHOT_GIRQ_POS		17
+
+#define MCHP_PROCHOT_GIRQ_VAL		(1ul << MCHP_PROCHOT_GIRQ_POS)
+
+/* PROCHOT GIRQ aggregated NVIC input */
+#define MCHP_PROCHOT_NVIC_AGGR		9u
+
+/* PROCHOT direct NVIC inputs */
+#define MCHP_PROCHOT_NVIC_DIRECT	87u
+
+/* Cumulative Count register */
+#define MCHP_PROCHOT_CCNT_REG_OFS	0
+#define MCHP_PROCHOT_CCNT_REG_MASK	0x00fffffful
+
+/* Duty cycle count register */
+#define MCHP_PROCHOT_DCCNT_REG_OFS	4
+#define MCHP_PROCHOT_DCCNT_REG_MASK	0x00fffffful
+
+/* Duty cycle period register */
+#define MCHP_PROCHOT_DCPER_REG_OFS	8
+#define MCHP_PROCHOT_DCPER_REG_MASK	0x00fffffful
+
+/* Control and Status register */
+#define MCHP_PROCHOT_CTRLS_REG_OFS		0x0C
+#define MCHP_PROCHOT_CTRLS_REG_MASK		0x00000C3Ful
+#define MCHP_PROCHOT_CTRLS_EN_POS		0
+#define MCHP_PROCHOT_CTRLS_EN			(1ul << 0)
+#define MCHP_PROCHOT_CTRLS_PIN_POS		1
+#define MCHP_PROCHOT_CTRLS_PIN_HI		(1ul << 1)
+#define MCHP_PROCHOT_CTRLS_ASSERT_EN_POS	2
+#define MCHP_PROCHOT_CTRLS_ASSERT_EN		(1ul << 2)
+#define MCHP_PROCHOT_CTRLS_PERIOD_EN_POS	3
+#define MCHP_PROCHOT_CTRLS_PERIOD_EN		(1ul << 3)
+#define MCHP_PROCHOT_CTRLS_RESET_EN_POS		4
+#define MCHP_PROCHOT_CTRLS_RESET_EN		(1ul << 4)
+#define MCHP_PROCHOT_CTRLS_FILT_EN_POS		5
+#define MCHP_PROCHOT_CTRLS_FILT_EN		(1ul << 5)
+
+/* Assertion counter register */
+#define MCHP_PROCHOT_ASSERT_CNT_REG_OFS		0x10
+#define MCHP_PROCHOT_ASSERT_CNT_REG_MASK	0x0000fffful
+
+/* Assertion counter limit register */
+#define MCHP_PROCHOT_ASSERT_LIM_REG_OFS		0x14
+#define MCHP_PROCHOT_ASSERT_LIM_REG_MASK	0x0000fffful
+
+/**
+  * @brief Processor Hot Interface (PROCHOT)
+  */
+typedef struct prochot_regs {
+	__IOM uint32_t CUMUL_COUNT; /*!< (@ 0x0000) PROCHOT Cumulative Count */
+	__IOM uint32_t DUTY_COUNT; /*!< (@ 0x0004) PROCHOT Duty cycle count */
+	__IOM uint32_t DUTY_PERIOD; /*!< (@ 0x0008) PROCHOT Duty cycle period */
+	__IOM uint32_t CTRL_STS; /*!< (@ 0x000C) PROCHOT Control and Status */
+	__IOM uint32_t ASSERT_COUNT; /*!< (@ 0x0010) PROCHOT Assertion counter */
+	__IOM uint32_t ASSERT_LIMIT; /*!< (@ 0x0014) PROCHOT Assertion counter limit */
+} PROCHOT_Type;
+
+#endif	/* #ifndef _PROCHOT_H */
+/* end prochot.h */
+/**   @}
+ */

--- a/mec/mec1501/component/pwm.h
+++ b/mec/mec1501/component/pwm.h
@@ -1,0 +1,143 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file pwm.h
+ *MEC1501 Pulse width modulator controller registers
+ */
+/** @defgroup MEC1501 Peripherals PWM
+ */
+
+#ifndef _PWM_H
+#define _PWM_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 PWM 				=========== */
+/* =========================================================================*/
+
+#define MCHP_PWM_BASE_ADDR		0x40005800ul
+
+#define MCHP_PWM_MAX_INSTANCES		9u
+#define MCHP_PWM_INST_SPACING		0x10ul
+#define MCHP_PWM_INST_SPACING_P2	4u
+
+#define MCHP_PWM_ADDR(n)	(MCHP_PWM_BASE_ADDR + \
+				 ((n) << MCHP_PWM_INST_SPACING_P2))
+
+/*
+ * PWM does not generate interrupts.
+ */
+
+/*
+ * PWM Count On register
+ */
+#define MCHP_PWM_COUNT_ON_REG_OFS	0U
+#define MCHP_PWM_COUNT_ON_MASK		0xffffU
+
+/*
+ * PWM Count Off register
+ */
+#define MCHP_PWM_COUNT_OFF_REG_OFS	4U
+#define MCHP_PWM_COUNT_OFF_MASK		0xffffU
+
+/*
+ * PWM Configuration Register
+ */
+#define MCHP_PWM_CONFIG_REG_OFS		8U
+#define MCHP_PWM_CONFIG_MASK		0x7FU
+/*
+ * Enable and start PWM. Clearing this bit resets internal counters.
+ * COUNT_ON and COUNT_OFF registers are not affected by enable bit.
+ */
+#define MCHP_PWM_CFG_ENABLE_POS		0
+#define MCHP_PWM_CFG_ENABLE		(1U << MCHP_PWM_CFG_ENABLE_POS)
+/*
+ * Clock select
+ */
+#define MCHP_PWM_CFG_CLK_SEL_POS	1
+#define MCHP_PWM_CFG_CLK_SEL_48M	(0U << MCHP_PWM_CFG_CLK_SEL_POS)
+#define MCHP_PWM_CFG_CLK_SEL_100K	(1U << MCHP_PWM_CFG_CLK_SEL_POS)
+/*
+ * ON state polarity.
+ * Default ON state is High.
+ */
+#define MCHP_PWM_CFG_ON_POL_POS		2
+#define MCHP_PWM_CFG_ON_POL_HI		(0U << MCHP_PWM_CFG_ON_POL_POS)
+#define MCHP_PWM_CFG_ON_POL_LO		(1U << MCHP_PWM_CFG_ON_POL_POS)
+/*
+ * Clock pre-divider
+ * Clock divider value = pre-divider + 1
+ */
+#define MCHP_PWM_CFG_CLK_PRE_DIV_POS	3
+#define MCHP_PWM_CFG_CLK_PRE_DIV_MASK0	0x0FU
+#define MCHP_PWM_CFG_CLK_PRE_DIV_MASK	\
+		(0x0FU << MCHP_PWM_CFG_CLK_PRE_DIV_POS)
+#define MCHP_PWM_CFG_CLK_PRE_DIV(n)	( \
+		((n) & MCHP_PWM_CFG_CLK_PRE_DIV_MASK0) \
+		 << MCHP_PWM_CFG_CLK_PRE_DIV_POS )
+
+/* PWM input frequencies selected in configuration register. */
+#define MCHP_PWM_INPUT_FREQ_HI	48000000U
+#define MCHP_PWM_INPUT_FREQ_LO	100000U
+
+/*
+ * Register access
+ * 0 <= n < MCHP_PWM_MAX_INSTANCES
+ */
+#define MCHP_PWM_COUNT_ON(n) \
+	REG16(MCHP_PWM_ADDR(n) + MCHP_PWM_COUNT_ON_REG_OFS)
+
+#define MCHP_PWM_COUNT_OFF(n) \
+	REG16(MCHP_PWM_ADDR(n) + MCHP_PWM_COUNT_OFF_REG_OFS)
+
+#define MCHP_PWM_CONFIG(n) \
+	REG8(MCHP_PWM_ADDR(n) + MCHP_PWM_CONFIG_REG_OFS)
+
+/*
+ * PWM Frequency =
+ * (1 / (pre_div + 1)) * PWM_INPUT_FREQ / ((COUNT_ON+1) + (COUNT_OFF+1))
+ *
+ * PWM Duty Cycle =
+ * (COUNT_ON+1) / ((COUNT_ON+1) + (COUNT_OFF + 1))
+ */
+
+/**
+  * @brief Pulse Width Modulator Registers (PWM)
+  */
+typedef struct pwm_regs {
+	__IOM uint32_t COUNT_ON; /*!< (@ 0x0000) PWM Counter ON b[15:0] */
+	__IOM uint32_t COUNT_OFF; /*!< (@ 0x0004) PWM Counter OFF b[15:0] */
+	__IOM uint32_t CONFIG;	/*!< (@ 0x0008) PWM Configuration b[7:0] */
+} PWM_Type;
+
+#endif	/* #ifndef _PWM_H */
+/* end pwm.h */
+/**   @}
+ */

--- a/mec/mec1501/component/qmspi.h
+++ b/mec/mec1501/component/qmspi.h
@@ -51,15 +51,19 @@
 #define MCHP_QMSPI_GIRQ_NUM		18u
 #define MCHP_QMSPI_GIRQ_POS		1u
 #define MCHP_QMSPI_GIRQ_OFS		(((MCHP_QMSPI0_GIRQ_NUM) - 8) * 20u)
-#define MCHP_QMSPI_GIRQ_BASE_ADDR	0x4000E0C8ul
-/* Sleep Enable 4 bit 8 */
-#define MCHP_QMSPI_PCR_SLP_EN_ADDR	0x40080140ul
-#define MCHP_QMSPI_PCR_SLP_EN_BITPOS	8u
 
+#define MCHP_QMSPI_GIRQ_NVIC_AGGR	10u
+#define MCHP_QMSPI_GIRQ_NVIC_DIRECT	91u
+
+#define MCHP_QMSPI_GIRQ_BASE_ADDR	0x4000E0C8ul
 #define MCHP_QMSPI_GIRQ_SRC_ADDR	(MCHP_QMSPI_GIRQ_BASE_ADDR)
 #define MCHP_QMSPI_GIRQ_ENSET_ADDR	(MCHP_QMSPI_GIRQ_BASE_ADDR + 0x04ul)
 #define MCHP_QMSPI_GIRQ_RESULT_ADDR	(MCHP_QMSPI_GIRQ_BASE_ADDR + 0x08ul)
 #define MCHP_QMSPI_GIRQ_ENCLR_ADDR	(MCHP_QMSPI_GIRQ_BASE_ADDR + 0x0Cul)
+
+/* Sleep Enable 4 bit 8 */
+#define MCHP_QMSPI_PCR_SLP_EN_ADDR	0x40080140ul
+#define MCHP_QMSPI_PCR_SLP_EN_POS	8u
 
 #define MCHP_QMSPI_GIRQ_EN		(1ul << (MCHP_QMSPI_GIRQ_POS))
 #define MCHP_QMSPI_GIRQ_STS		(1ul << (MCHP_QMSPI_GIRQ_POS))
@@ -111,11 +115,27 @@
 #define MCHP_QMSPI_RXB_ADDR		(MCHP_QMSPI_BASE_ADDR + 0x24)
 #define MCHP_QMSPI_CSTM_ADDR		(MCHP_QMSPI_BASE_ADDR + 0x28)
 #define MCHP_QMSPI_DESCR_ADDR(n) \
-	(MCHP_QMSPI_BASE_ADDR + (0x30 + ((uint32_t)(n) << 2)))
+	(MCHP_QMSPI_BASE_ADDR + (0x30 + (((uint32_t)(n) & 0x0Ful) << 2)))
 
 /* Mode Register */
 #define MCHP_QMSPI_M_SRST		0x02ul
 #define MCHP_QMSPI_M_ACTIVATE		0x01ul
+#define MCHP_QMSPI_M_CPOL_POS		8u
+#define MCHP_QMSPI_M_CPOL_CLK_IDLE_LO	(0ul << 8)
+#define MCHP_QMSPI_M_CPOL_CLK_IDLE_HI	(0ul << 8)
+
+#define MCHP_QMSPI_M_CPHA_MOSI_POS	9u
+/* MOSI data changes on first clock edge of clock pulse */
+#define MCHP_QMSPI_M_CPHA_MOSI_CE1	(0ul << 9)
+/* MOSI data changes on second clock edge of clock pulse */
+#define MCHP_QMSPI_M_CPHA_MOSI_CE2	(1ul << 9)
+
+#define MCHP_QMSPI_M_CPHA_MIS0_POS	10u
+/* MISO data capture on first clock edge of clock pulse */
+#define MCHP_QMSPI_M_CPHA_MISO_CE1	(0ul << 9)
+/* MISO data capture on second clock edge of clock pulse */
+#define MCHP_QMSPI_M_CPHA_MISO_CE2	(1ul << 9)
+
 #define MCHP_QMSPI_M_SIG_POS		8u
 #define MCHP_QMSPI_M_SIG_MASK0		0x07ul
 #define MCHP_QMSPI_M_SIG_MASK		0x0700ul
@@ -231,7 +251,9 @@
 
 /* Buffer Count Status (RO) */
 #define MCHP_QMSPI_TX_BUF_CNT_STS_POS	0u
+#define MCHP_QMSPI_TX_BUF_CNT_STS_MASK	0xffffu
 #define MCHP_QMSPI_RX_BUF_CNT_STS_POS	16u
+#define MCHP_QMSPI_RX_BUF_CNT_STS_MASK	0xffff0000ul
 
 /* Interrupt Enable Register */
 #define MCHP_QMSPI_IEN_XFR_DONE		(1ul << 0)
@@ -333,11 +355,6 @@
  * 0 <= id < MCHP_QMSPI_MAX_DESCR
  */
 #define MCHP_QMSPI_DESCR(id)	REG32(MCHP_QMSPI_DESCR_ADDR(id))
-#define MCHP_QMSPI_DESCR0()	REG32(MCHP_QMSPI_DESCR_ADDR(0))
-#define MCHP_QMSPI_DESCR1()	REG32(MCHP_QMSPI_DESCR_ADDR(1))
-#define MCHP_QMSPI_DESCR2()	REG32(MCHP_QMSPI_DESCR_ADDR(2))
-#define MCHP_QMSPI_DESCR3()	REG32(MCHP_QMSPI_DESCR_ADDR(3))
-#define MCHP_QMSPI_DESCR4()	REG32(MCHP_QMSPI_DESCR_ADDR(4))
 
 #define MCHP_QMSPI_DESCR_NUNITS(id, nu) MCHP_QMSPI_DESCR(id) = \
 	((MCHP_QMSPI_DESCR(id) & ~(MCHP_QMSPI_C_XFR_NUNITS_MASK)) +\
@@ -348,27 +365,38 @@
 /* ================	       QMSPI			   ================ */
 /* =========================================================================*/
 
-typedef struct {
-	__IOM uint32_t u32;
-} QMSPI_DESCR_Type;
-
 /**
   * @brief Quad Master SPI (QMSPI)
   */
-typedef struct qmspi_regs
-{
-	__IOM uint32_t MODE;	/*!< (@ 0x00000000) QMSPI Mode */
-	__IOM uint32_t CTRL;	/*!< (@ 0x00000004) QMSPI Control */
-	__IOM uint32_t EXE;	/*!< (@ 0x00000008) QMSPI Execute */
-	__IOM uint32_t IFCTRL;	/*!< (@ 0x0000000C) QMSPI Interface control */
-	__IOM uint32_t STS;	/*!< (@ 0x00000010) QMSPI Status */
-	__IOM uint32_t BCNT_STS;	/*!< (@ 0x00000014) QMSPI Buffer Count Status (RO) */
-	__IOM uint32_t IEN;	/*!< (@ 0x00000018) QMSPI Interrupt Enable */
-	__IOM uint32_t BCNT_TRIG;	/*!< (@ 0x0000001C) QMSPI Buffer Count Trigger */
-	__IOM uint32_t TX_FIFO;	/*!< (@ 0x00000020) QMSPI TX FIFO */
-	__IOM uint32_t RX_FIFO;	/*!< (@ 0x00000024) QMSPI RX FIFO */
-	uint8_t RSVD1[8];
-	QMSPI_DESCR_Type DESCR[QMSPI_MAX_DESCR];	/*!< (@ 0x00000030) QMSPI Descriptors 0-4 */
+typedef struct qmspi_regs {
+	__IOM uint32_t MODE; /*!< (@ 0x0000) QMSPI Mode */
+	__IOM uint32_t CTRL; /*!< (@ 0x0004) QMSPI Control */
+	__IOM uint32_t EXE; /*!< (@ 0x0008) QMSPI Execute */
+	__IOM uint32_t IFCTRL; /*!< (@ 0x000C) QMSPI Interface control */
+	__IOM uint32_t STS; /*!< (@ 0x0010) QMSPI Status */
+	__IOM uint32_t BCNT_STS; /*!< (@ 0x0014) QMSPI Buffer Count Status (RO) */
+	__IOM uint32_t IEN; /*!< (@ 0x0018) QMSPI Interrupt Enable */
+	__IOM uint32_t BCNT_TRIG; /*!< (@ 0x001C) QMSPI Buffer Count Trigger */
+	__IOM uint32_t TX_FIFO; /*!< (@ 0x0020) QMSPI TX FIFO */
+	__IOM uint32_t RX_FIFO; /*!< (@ 0x0024) QMSPI RX FIFO */
+	__IOM uint32_t CSTM; /*!< (@ 0x0028) QMSPI Chip select timing */
+	uint8_t RSVD1[4];
+	__IOM uint32_t DESCR0; /*!< (@ 0x0030) QMSPI Descriptor 0 */
+	__IOM uint32_t DESCR1; /*!< (@ 0x0034) QMSPI Descriptor 1 */
+	__IOM uint32_t DESCR2; /*!< (@ 0x0038) QMSPI Descriptor 2 */
+	__IOM uint32_t DESCR3; /*!< (@ 0x003C) QMSPI Descriptor 3 */
+	__IOM uint32_t DESCR4; /*!< (@ 0x0040) QMSPI Descriptor 4 */
+	__IOM uint32_t DESCR5; /*!< (@ 0x0044) QMSPI Descriptor 5 */
+	__IOM uint32_t DESCR6; /*!< (@ 0x0048) QMSPI Descriptor 6 */
+	__IOM uint32_t DESCR7; /*!< (@ 0x004C) QMSPI Descriptor 7 */
+	__IOM uint32_t DESCR8; /*!< (@ 0x0050) QMSPI Descriptor 8 */
+	__IOM uint32_t DESCR9; /*!< (@ 0x0054) QMSPI Descriptor 9 */
+	__IOM uint32_t DESCR10; /*!< (@ 0x0058) QMSPI Descriptor 10 */
+	__IOM uint32_t DESCR11; /*!< (@ 0x005C) QMSPI Descriptor 11 */
+	__IOM uint32_t DESCR12; /*!< (@ 0x0060) QMSPI Descriptor 12 */
+	__IOM uint32_t DESCR13; /*!< (@ 0x0064) QMSPI Descriptor 13 */
+	__IOM uint32_t DESCR14; /*!< (@ 0x0068) QMSPI Descriptor 14 */
+	__IOM uint32_t DESCR15; /*!< (@ 0x006C) QMSPI Descriptor 15 */
 } QMSPI_Type;
 
 #endif				/* #ifndef _QMSPI_H */

--- a/mec/mec1501/component/rtc.h
+++ b/mec/mec1501/component/rtc.h
@@ -1,0 +1,167 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file rtc.h
+ *MEC1501 Real Time Clock definitions
+ */
+/** @defgroup MEC1501 Peripherals RTC
+ */
+
+#ifndef _RTC_H
+#define _RTC_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 RTC 			=================== */
+/* =========================================================================*/
+
+/* Hours register */
+#define MCHP_RTC_HOURS_REG_OFS		0x04u
+#define MCHP_RTC_HOURS_MASK		0x7Fu
+#define MCHP_RTC_HOURS_AM_PM_MASK	0x80u
+#define MCHP_RTC_HOURS_PM		0x80u
+
+/* RegA */
+#define MCHP_RTC_REGA_REG_OFS			0x0Aul
+#define MCHP_RTC_REGA_MASK			0xFFu
+#define MCHP_RTC_REGA_RATE_SEL_POS		0
+#define MCHP_RTC_REGA_RATE_SEL_MASK0		0x0Fu
+#define MCHP_RTC_REGA_RATE_SEL_MASK		0x0Fu
+#define MCHP_RTC_REGA_RATE_NONE			0x00u
+#define MCHP_RTC_REGA_RATE_3906250_NS		0x01u
+#define MCHP_RTC_REGA_RATE_7812500_NS		0x02u
+#define MCHP_RTC_REGA_RATE_122070_NS		0x03u
+#define MCHP_RTC_REGA_RATE_244141_NS		0x04u
+#define MCHP_RTC_REGA_RATE_488281_NS		0x05u
+#define MCHP_RTC_REGA_RATE_976563_NS		0x06u
+#define MCHP_RTC_REGA_RATE_1953125_NS		0x07u
+#define MCHP_RTC_REGA_RATE_3906250_NS_ALT	0x08u
+#define MCHP_RTC_REGA_RATE_7812500_NS_ALT	0x09u
+#define MCHP_RTC_REGA_RATE_15625_US		0x0Au
+#define MCHP_RTC_REGA_RATE_31250_US		0x0Bu
+#define MCHP_RTC_REGA_RATE_62500_US		0x0Cu
+#define MCHP_RTC_REGA_RATE_125000_US		0x0Du
+#define MCHP_RTC_REGA_RATE_250000_US		0x0Du
+#define MCHP_RTC_REGA_RATE_500000_US		0x0Du
+#define MCHP_RTC_REGA_DIVC_SEL_POS		4
+#define MCHP_RTC_REGA_DIVC_SEL_MASK0		0x07u
+#define MCHP_RTC_REGA_DIVC_SEL_MASK		0x70u
+#define MCHP_RTC_REGA_DIVC_SEL_NORM		(0x02u << 4)
+#define MCHP_RTC_REGA_DIVC_SEL_HALT		(0x03u << 4)
+/* bit[7] is read-only status */
+#define MCHP_RTC_REGA_UPDATE_IN_PROGESS_POS	7
+#define MCHP_RTC_REGA_UPDATE_IN_PROGESS		0x80
+
+/* RegB */
+#define MCHP_RTC_REGB_REG_OFS		0x0Bul
+#define MCHP_RTC_REGB_MASK		0xF7u
+#define MCHP_RTC_REGB_DS_EN		0x01u
+#define MCHP_RTC_REGB_FMT_12H		0x00u
+#define MCHP_RTC_REGB_FMT_24H		0x02u
+#define MCHP_RTC_REGB_DATA_BCD		0x00u
+#define MCHP_RTC_REGB_DATA_BIN		0x04u
+#define MCHP_RTC_REGB_UPDATE_DONE_IEN	0x10u
+#define MCHP_RTC_REGB_ALARM_IEN		0x20u
+#define MCHP_RTC_REGB_PERIODIC_IEN	0x40u
+#define MCHP_RTC_REGB_UPDATE_INHIBIT	0x80u
+
+/* RegC contains read-to-clear status */
+#define MCHP_RTC_REGC_REG_OFS		0x0Cul
+#define MCHP_RTC_REGC_MASK		0xF0u
+#define MCHP_RTC_REGC_UPDATE_DONE_STS	0x10u
+#define MCHP_RTC_REGC_ALARM_STS		0x20u
+#define MCHP_RTC_REGC_PERIODIC_STS	0x40u
+#define MCHP_RTC_REGC_INT_REQ_STS	0x80u
+
+/* RegD */
+#define MCHP_RTC_REGD_REG_OFS		0x0Dul
+#define MCHP_RTC_REGD_MASK		0x3Fu
+#define MCHP_RTC_REGD_DATE_ALARM_MASK	0x3Fu
+
+/* Control */
+#define MCHP_RTC_CTRL_REG_OFS		0x10ul
+#define MCHP_RTC_CTRL_MASK		0x0Fu
+#define MCHP_RTC_CTRL_BLK_EN		0x01u
+#define MCHP_RTC_CTRL_SRST		0x02u
+#define MCHP_RTC_CTRL_RSVD2		0x04u
+#define MCHP_RTC_CTRL_ALARM_EN		0x08u
+
+/* Daylight savings forward (DLSF) and backward (DLSB) registers */
+#define MCHP_RTC_DLSF_REG_OFS		0x18ul
+#define MCHP_RTC_DLSB_REG_OFS		0x1Cul
+#define MCHP_RTC_DLS_MASK		0xFF0707FFul
+#define MCHP_RTC_DLS_MON_POS		0
+#define MCHP_RTC_DLS_MON_MASK		0xFFul
+#define MCHP_RTC_DLS_DOFW_POS		8
+#define MCHP_RTC_DLS_DOFW_MASK		(0x07ul << 8)
+#define MCHP_RTC_DLS_WEEK_POS		16
+#define MCHP_RTC_DLS_WEEK_MASK		(0x07ul << 16)
+#define MCHP_RTC_DLS_WEEK_1		(1ul << 16)
+#define MCHP_RTC_DLS_WEEK_2		(2ul << 16)
+#define MCHP_RTC_DLS_WEEK_3		(3ul << 16)
+#define MCHP_RTC_DLS_WEEK_4		(4ul << 16)
+#define MCHP_RTC_DLS_WEEK_LAST		(5ul << 16)
+#define MCHP_RTC_DLS_HOUR_POS		24
+#define MCHP_RTC_DLS_HOUR_MASK		(0x3Ful << 24)
+#define MCHP_RTC_DLS_AM_PM_POS		31
+#define MCHP_RTC_DLS_PM			(1ul << 31)
+
+
+/**
+  * @brief Real Time Clock (RTC)
+  */
+typedef struct rtc_regs {
+	__IOM uint8_t  SECONDS;		/*! (@ 0x0000) RTC seconds */
+	__IOM uint8_t  SEC_ALARM;	/*! (@ 0x0001) RTC seconds alarm */
+	__IOM uint8_t  MINUTES;		/*! (@ 0x0002) RTC minutes */
+	__IOM uint8_t  MIN_ALARM;	/*! (@ 0x0003) RTC minutes alarm */
+	__IOM uint8_t  HOURS;		/*! (@ 0x0004) RTC hours */
+	__IOM uint8_t  HOURS_ALARM;	/*! (@ 0x0005) RTC hours alarm */
+	__IOM uint8_t  DAY_OF_WEEK;	/*! (@ 0x0006) RTC day of week */
+	__IOM uint8_t  DAY_OF_MONTH;	/*! (@ 0x0007) RTC day of month */
+	__IOM uint8_t  MONTH;		/*! (@ 0x0008) RTC month */
+	__IOM uint8_t  YEAR;		/*! (@ 0x0009) RTC year */
+	__IOM uint8_t  REGA;		/*! (@ 0x000A) RTC Reg A */
+	__IOM uint8_t  REGB;		/*! (@ 0x000B) RTC Reg B */
+	__IOM uint8_t  REGC;		/*! (@ 0x000C) RTC Reg C */
+	__IOM uint8_t  REGD;		/*! (@ 0x000D) RTC Reg D */
+	uint8_t RSVD1[2];
+	__IOM uint8_t  CONTROL;		/*! (@ 0x0010) RTC Control */
+	uint8_t RSVD2[3];
+	__IOM uint8_t  WEEK_ALARM;	/*! (@ 0x0014) RTC Alarm day of week */
+	uint8_t RSVD3[3];
+	__IOM uint32_t  DLSF;		/*! (@ 0x0018) RTC Daylight savings forward */
+	__IOM uint32_t  DLSB;		/*! (@ 0x0018) RTC Daylight savings backward */
+} RTC_Type;
+
+#endif /* #ifndef _RTC_H */
+/* end rtc.h */
+/**   @}
+ */

--- a/mec/mec1501/component/spi_slave.h
+++ b/mec/mec1501/component/spi_slave.h
@@ -1,0 +1,341 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file spi_slave.h
+ *MEC1501 SPI Slave registers
+ */
+/** @defgroup MEC1501 Peripherals SPI Slave
+ */
+
+#ifndef _SPI_SLAVE_H
+#define _SPI_SLAVE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 SPISLV 			=========== */
+/* =========================================================================*/
+
+#define MCHP_SPISLV_BASE_ADDR	0x40007000ul
+
+/*
+ * SPISLV interrupts
+ */
+#define MCHP_SPISLV_GIRQ	18u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_SPISLV_GIRQ_POS	0u
+
+#define MCHP_SPISLV_GIRQ_VAL	(1ul << MCHP_SPISLV_GIRQ_POS)
+
+/* SPISLV GIRQ aggregated NVIC input */
+#define MCHP_SPISLV_NVIC_AGGR	10u
+
+/* SPISLV direct NVIC inputs */
+#define MCHP_SPISLV_NVIC_DIRECT	90u
+
+/* SPISLV Configuration register */
+#define MCHP_SPISLV_CFG_REG_OFS		0
+#define MCHP_SPISLV_CFG_REG_MASK	0x00ff0301ul
+#define MCHP_SPISLV_CFG_SQ_SEL_POS	0
+#define MCHP_SPISLV_CFG_SINGLE		(0ul << 0)
+#define MCHP_SPISLV_CFG_QUAD		(1ul << 0)
+#define MCHP_SPISLV_CFG_TAR_POS		8
+#define MCHP_SPISLV_CFG_TAR_MASK0	0x03u
+#define MCHP_SPISLV_CFG_TAR_MASK	(0x03ul << 8)
+#define MCHP_SPISLV_CFG_TAR_1		(0x00ul << 8)
+#define MCHP_SPISLV_CFG_TAR_2		(0x01ul << 8)
+#define MCHP_SPISLV_CFG_TAR_4		(0x02ul << 8)
+#define MCHP_SPISLV_CFG_TAR_8		(0x03ul << 8)
+#define MCHP_SPISLV_CFG_WTM_POS		16
+#define MCHP_SPISLV_CFG_WTM_MASK0	0xffu
+#define MCHP_SPISLV_CFG_WTM_MASK	(0xfful << 16)
+
+/* SPISLV Status register */
+#define MCHP_SPISLV_STS_REG_OFS		4
+#define MCHP_SPISLV_STS_REG_MASK	0x1FFFEF7Bul
+#define MCHP_SPISLV_SPI_STS_MWD		(1ul << 0)
+#define MCHP_SPISLV_SPI_STS_MRD		(1ul << 1)
+#define MCHP_SPISLV_SPI_STS_MWB		(1ul << 3)
+#define MCHP_SPISLV_SPI_STS_MRB		(1ul << 4)
+#define MCHP_SPISLV_SPI_STS_SRTB	(1ul << 5)
+#define MCHP_SPISLV_SPI_STS_PHI_REQ	(1ul << 6)
+#define MCHP_SPISLV_SPI_STS_RXFE	(1ul << 8)
+#define MCHP_SPISLV_SPI_STS_RXFF	(1ul << 9)
+#define MCHP_SPISLV_SPI_STS_TXFE	(1ul << 10)
+#define MCHP_SPISLV_SPI_STS_TXFF	(1ul << 11)
+#define MCHP_SPISLV_SPI_STS_SCCE	(1ul << 13)
+#define MCHP_SPISLV_SPI_STS_OBF		(1ul << 15)
+#define MCHP_SPISLV_SPI_STS_SPIMR	(1ul << 16)
+#define MCHP_SPISLV_SPI_STS_RXF_RSTD	(1ul << 17)
+#define MCHP_SPISLV_SPI_STS_TXF_RSTD	(1ul << 18)
+#define MCHP_SPISLV_SPI_STS_LIM0	(1ul << 19)
+#define MCHP_SPISLV_SPI_STS_LIM1	(1ul << 20)
+#define MCHP_SPISLV_SPI_STS_ABERR	(1ul << 21)
+#define MCHP_SPISLV_SPI_STS_UNDEF_CMD	(1ul << 22)
+#define MCHP_SPISLV_SPI_STS_DVB		(1ul << 23)
+#define MCHP_SPISLV_SPI_STS_RXF_SZ	(1ul << 24)
+#define MCHP_SPISLV_SPI_STS_TXF_UNF	(1ul << 25)
+#define MCHP_SPISLV_SPI_STS_TXF_OVF	(1ul << 26)
+#define MCHP_SPISLV_SPI_STS_RXF_UNF	(1ul << 27)
+#define MCHP_SPISLV_SPI_STS_RXF_OVF	(1ul << 28)
+
+/* SPISLV EC Status register */
+#define MCHP_SPISLV_EC_STS_REG_OFS	8
+#define MCHP_SPISLV_EC_STS_REG_MASK	0x1FFFEF7Bul
+#define MCHP_SPISLV_EC_STS_MWD		(1ul << 0)
+#define MCHP_SPISLV_EC_STS_MRD		(1ul << 1)
+#define MCHP_SPISLV_EC_STS_MWB		(1ul << 3)
+#define MCHP_SPISLV_EC_STS_MRB		(1ul << 4)
+#define MCHP_SPISLV_EC_STS_SRTB		(1ul << 5)
+#define MCHP_SPISLV_EC_STS_PHI_REQ	(1ul << 6)
+#define MCHP_SPISLV_EC_STS_RXFE		(1ul << 8)
+#define MCHP_SPISLV_EC_STS_RXFF		(1ul << 9)
+#define MCHP_SPISLV_EC_STS_TXFE		(1ul << 10)
+#define MCHP_SPISLV_EC_STS_TXFF		(1ul << 11)
+#define MCHP_SPISLV_EC_STS_SCCE		(1ul << 13)
+#define MCHP_SPISLV_EC_STS_IBF		(1ul << 14)
+#define MCHP_SPISLV_EC_STS_OBF		(1ul << 15)
+#define MCHP_SPISLV_EC_STS_SPIMR	(1ul << 16)
+#define MCHP_SPISLV_EC_STS_RXF_RSTD	(1ul << 17)
+#define MCHP_SPISLV_EC_STS_TXF_RSTD	(1ul << 18)
+#define MCHP_SPISLV_EC_STS_LIM0		(1ul << 19)
+#define MCHP_SPISLV_EC_STS_LIM1		(1ul << 20)
+#define MCHP_SPISLV_EC_STS_ABERR	(1ul << 21)
+#define MCHP_SPISLV_EC_STS_UNDEF_CMD	(1ul << 22)
+#define MCHP_SPISLV_EC_STS_DVB		(1ul << 23)
+#define MCHP_SPISLV_EC_STS_RXF_SZ	(1ul << 24)
+#define MCHP_SPISLV_EC_STS_TXF_UNF	(1ul << 25)
+#define MCHP_SPISLV_EC_STS_TXF_OVF	(1ul << 26)
+#define MCHP_SPISLV_EC_STS_RXF_UNF	(1ul << 27)
+#define MCHP_SPISLV_EC_STS_RXF_OVF	(1ul << 28)
+
+/* SPISLV SPI Interrupt Enable register */
+#define MCHP_SPISLV_SPI_IEN_REG_OFS	0x0C
+#define MCHP_SPISLV_SPI_IEN_REG_MASK	0x1FFFAF7Bul
+#define MCHP_SPISLV_SPI_IEN_MWD		(1ul << 0)
+#define MCHP_SPISLV_SPI_IEN_MRD		(1ul << 1)
+#define MCHP_SPISLV_SPI_IEN_MWB		(1ul << 3)
+#define MCHP_SPISLV_SPI_IEN_MRB		(1ul << 4)
+#define MCHP_SPISLV_SPI_IEN_SRTB	(1ul << 5)
+#define MCHP_SPISLV_SPI_IEN_PHI_REQ	(1ul << 6)
+#define MCHP_SPISLV_SPI_IEN_RXFE	(1ul << 8)
+#define MCHP_SPISLV_SPI_IEN_RXFF	(1ul << 9)
+#define MCHP_SPISLV_SPI_IEN_TXFE	(1ul << 10)
+#define MCHP_SPISLV_SPI_IEN_TXFF	(1ul << 11)
+#define MCHP_SPISLV_SPI_IEN_SCCE	(1ul << 13)
+#define MCHP_SPISLV_SPI_IEN_OBF		(1ul << 15)
+#define MCHP_SPISLV_SPI_IEN_SPIMR	(1ul << 16)
+#define MCHP_SPISLV_SPI_IEN_RXF_RSTD	(1ul << 17)
+#define MCHP_SPISLV_SPI_IEN_TXF_RSTD	(1ul << 18)
+#define MCHP_SPISLV_SPI_IEN_LIM0	(1ul << 19)
+#define MCHP_SPISLV_SPI_IEN_LIM1	(1ul << 20)
+#define MCHP_SPISLV_SPI_IEN_ABERR	(1ul << 21)
+#define MCHP_SPISLV_SPI_IEN_UNDEF_CMD	(1ul << 22)
+#define MCHP_SPISLV_SPI_IEN_DVB		(1ul << 23)
+#define MCHP_SPISLV_SPI_IEN_RXF_SZ	(1ul << 24)
+#define MCHP_SPISLV_SPI_IEN_TXF_UNF	(1ul << 25)
+#define MCHP_SPISLV_SPI_IEN_TXF_OVF	(1ul << 26)
+#define MCHP_SPISLV_SPI_IEN_RXF_UNF	(1ul << 27)
+#define MCHP_SPISLV_SPI_IEN_RXF_OVF	(1ul << 28)
+
+/* SPISLV EC Interrupt Enable register */
+#define MCHP_SPISLV_EC_IEN_REG_OFS	0x10
+#define MCHP_SPISLV_EC_IEN_REG_MASK	0x1FFFEF7Bul
+#define MCHP_SPISLV_EC_IEN_MWD		(1ul << 0)
+#define MCHP_SPISLV_EC_IEN_MRD		(1ul << 1)
+#define MCHP_SPISLV_EC_IEN_MWB		(1ul << 3)
+#define MCHP_SPISLV_EC_IEN_MRB		(1ul << 4)
+#define MCHP_SPISLV_EC_IEN_SRTB		(1ul << 5)
+#define MCHP_SPISLV_EC_IEN_PHI_REQ	(1ul << 6)
+#define MCHP_SPISLV_EC_IEN_RXFE		(1ul << 8)
+#define MCHP_SPISLV_EC_IEN_RXFF		(1ul << 9)
+#define MCHP_SPISLV_EC_IEN_TXFE		(1ul << 10)
+#define MCHP_SPISLV_EC_IEN_TXFF		(1ul << 11)
+#define MCHP_SPISLV_EC_IEN_SCCE		(1ul << 13)
+#define MCHP_SPISLV_EC_IEN_IBF		(1ul << 14)
+#define MCHP_SPISLV_EC_IEN_OBF		(1ul << 15)
+#define MCHP_SPISLV_EC_IEN_SPIMR	(1ul << 16)
+#define MCHP_SPISLV_EC_IEN_RXF_RSTD	(1ul << 17)
+#define MCHP_SPISLV_EC_IEN_TXF_RSTD	(1ul << 18)
+#define MCHP_SPISLV_EC_IEN_LIM0		(1ul << 19)
+#define MCHP_SPISLV_EC_IEN_LIM1		(1ul << 20)
+#define MCHP_SPISLV_EC_IEN_ABERR	(1ul << 21)
+#define MCHP_SPISLV_EC_IEN_UNDEF_CMD	(1ul << 22)
+#define MCHP_SPISLV_EC_IEN_DVB		(1ul << 23)
+#define MCHP_SPISLV_EC_IEN_RXF_SZ	(1ul << 24)
+#define MCHP_SPISLV_EC_IEN_TXF_UNF	(1ul << 25)
+#define MCHP_SPISLV_EC_IEN_TXF_OVF	(1ul << 26)
+#define MCHP_SPISLV_EC_IEN_RXF_UNF	(1ul << 27)
+#define MCHP_SPISLV_EC_IEN_RXF_OVF	(1ul << 28)
+
+/* SPISLV Memory Config register */
+#define MCHP_SPISLV_MCFG_REG_OFS	0x14
+#define MCHP_SPISLV_MCFG_REG_MASK	0x03ul
+#define MCHP_SPISLV_MCFG_BAR0_EN_POS	0
+#define MCHP_SPISLV_MCFG_BAR0_EN	(1ul << 0)
+#define MCHP_SPISLV_MCFG_BAR1_EN_POS	1
+#define MCHP_SPISLV_MCFG_BAR1_EN	(1ul << 1)
+
+/* SPISLV Memory Base Address 0 register */
+#define MCHP_SPISLV_MBA0_REG_OFS	0x18
+#define MCHP_SPISLV_MBA0_REG_MASK	0xFFFFFFFCul
+
+/* SPISLV Memory Write Limit 0 register */
+#define MCHP_SPISLV_MWLIM0_REG_OFS	0x1C
+#define MCHP_SPISLV_MWLIM0_REG_MASK	0xFFFFFFFCul
+
+/* SPISLV Memory Read Limit 0 register */
+#define MCHP_SPISLV_MRLIM0_REG_OFS	0x20
+#define MCHP_SPISLV_MRLIM0_REG_MASK	0xFFFFFFFCul
+
+/* SPISLV Memory Base Address 1 register */
+#define MCHP_SPISLV_MBA1_REG_OFS	0x24
+#define MCHP_SPISLV_MBA1_REG_MASK	0xFFFFFFFCul
+
+/* SPISLV Memory Write Limit 1 register */
+#define MCHP_SPISLV_MWLIM1_REG_OFS	0x28
+#define MCHP_SPISLV_MWLIM1_REG_MASK	0xFFFFFFFCul
+
+/* SPISLV Memory Read Limit 1 register */
+#define MCHP_SPISLV_MRLIM1_REG_OFS	0x2C
+#define MCHP_SPISLV_MRLIM1_REG_MASK	0xFFFFFFFCul
+
+/* SPISLV RX FIFO Host BAR register */
+#define MCHP_SPISLV_RXFHB_REG_OFS	0x30
+#define MCHP_SPISLV_RXFHB_REG_MASK	0xFFFFul
+
+/* SPISLV RX FIFO Host BAR register */
+#define MCHP_SPISLV_RXFBC_REG_OFS	0x34
+#define MCHP_SPISLV_RXFBC_REG_MASK	0x7FFFul
+
+/* SPISLV TX FIFO Host BAR register */
+#define MCHP_SPISLV_TXFHB_REG_OFS	0x38
+#define MCHP_SPISLV_TXFHB_REG_MASK	0xFFFFul
+
+/* SPISLV TX FIFO Host BAR register */
+#define MCHP_SPISLV_TXFBC_REG_OFS	0x3C
+#define MCHP_SPISLV_TXFBC_REG_MASK	0x7FFFul
+
+/* SPISLV System Configuration register */
+#define MCHP_SPISLV_SYSCFG_REG_OFS	0x40
+#define MCHP_SPISLV_SYSCFG_REG_MASK	0x000F04FFul
+#define MCHP_SPISLV_SYSCFG_SRST		(1ul << 0)
+#define MCHP_SPISLV_SYSCFG_LOCK_WM	(1ul << 1)
+#define MCHP_SPISLV_SYSCFG_LOCK_TAR	(1ul << 2)
+#define MCHP_SPISLV_SYSCFG_LOCK_WC	(1ul << 3)
+#define MCHP_SPISLV_SYSCFG_LOCK_SPI_STS	(1ul << 4)
+#define MCHP_SPISLV_SYSCFG_LOCK_SPI_IEN	(1ul << 5)
+#define MCHP_SPISLV_SYSCFG_LOCK_MBA0	(1ul << 6)
+#define MCHP_SPISLV_SYSCFG_LOCK_MBA1	(1ul << 7)
+#define MCHP_SPISLV_SYSCFG_LOCK_TST	(1ul << 10)
+#define MCHP_SPISLV_SYSCFG_LOCK_ALL	0x04FEul
+#define MCHP_SPISLV_SYSCFG_ACT		(1ul << 16)
+#define MCHP_SPISLV_SYSCFG_MASK_EC	(1ul << 17)
+#define MCHP_SPISLV_SYSCFG_SIMPLE_MODE	(1ul << 18)
+#define MCHP_SPISLV_SYSCFG_ECDA		(1ul << 19)
+
+/* SPISLV SPI Master to EC Mailbox register */
+#define MCHP_SPISLV_MB_S2EC_REG_OFS	0x44
+#define MCHP_SPISLV_MB_S2EC_REG_MASK	0xFFFFFFFFul
+#define MCHP_SPISLV_MB_S2EC_CLR		0xFFFFFFFFul
+
+/* SPISLV EC to SPI Master Mailbox register */
+#define MCHP_SPISLV_MB_EC2S_REG_OFS	0x48
+#define MCHP_SPISLV_MB_EC2S_REG_MASK	0xFFFFFFFFul
+#define MCHP_SPISLV_MB_EC2S_CLR		0xFFFFFFFFul
+
+/* SPI commands supported by SPISLV */
+#define SPISLV_CMD_IN_BAND_RST		0xFFu
+#define SPISLV_CMD_UNDEF_W32		0x01u
+#define SPISLV_CMD_UNDEF_W8		0x02u
+#define SPISLV_CMD_UNDEF_R32		0x05u
+#define SPISLV_CMD_UNDEF_R8		0x06u
+#define SPISLV_CMD_SREG_W8		0x09u
+#define SPISLV_CMD_SREG_W16		0x0Au
+#define SPISLV_CMD_SREG_W32		0x0Bu
+#define SPISLV_CMD_SREG_R8		0x0Du
+#define SPISLV_CMD_SREG_R16		0x0Eu
+#define SPISLV_CMD_SREG_R32		0x0Fu
+#define SPISLV_CMD_RST_RX_FIFO		0x12u
+#define SPISLV_CMD_RST_TX_FIFO		0x14u
+#define SPISLV_CMD_RST_RXTX_FIFO	0x16u
+#define SPISLV_CMD_MEM_W8		0x21u
+#define SPISLV_CMD_MEM_W16		0x22u
+#define SPISLV_CMD_MEM_W32		0x23u
+#define SPISLV_CMD_MEM_R8		0x25u
+#define SPISLV_CMD_MEM_R16		0x26u
+#define SPISLV_CMD_MEM_R32		0x27u
+#define SPISLV_CMD_RS_FIFO8		0x28u
+#define SPISLV_CMD_RS_FIFO16		0x29u
+#define SPISLV_CMD_RS_FIFO32		0x2Bu
+#define SPISLV_CMD_POLL_LO		0x2Cu
+#define SPISLV_CMD_POLL_HI		0x2Du
+#define SPISLV_CMD_POLL_ALL		0x2Fu
+#define SPISLV_CMD_EXT_REG_W8		0x41u
+#define SPISLV_CMD_EXT_REG_R8		0x45u
+#define SPISLV_CMD_RS_FIFO8_FSR		0x68u
+#define SPISLV_CMD_RS_FIFO16_FSR	0x69u
+#define SPISLV_CMD_RS_FIFO32_FSR	0x6Bu
+#define SPISLV_CMD_EXT_END		0x6Cu
+#define SPISLV_CMD_MBLK_W		0x80u
+#define SPISLV_CMD_MBLK_R		0xA0u
+#define SPISLV_CMD_RD_BLK_FIFO		0xC0u
+#define SPISLV_CMD_RD_BLK_FIFO_FSR	0xE0u
+
+
+/**
+  * @brief SPI Slave registers (SPISLV)
+  */
+typedef struct spislv_regs {
+	__IOM uint32_t CONFIG; /*!< (@ 0x0000) SPISLV Control */
+	__IOM uint32_t SLV_STATUS; /*!< (@ 0x0004) SPISLV Slave Status */
+	__IOM uint32_t EC_STATUS; /*!< (@ 0x0008) SPISLV EC Status */
+	__IOM uint32_t SPI_INT_EN; /*!< (@ 0x000C) SPISLV SPI Interrupt Enable */
+	__IOM uint32_t EC_INT_EN; /*!< (@ 0x0010) SPISLV EC Interrupt Enable */
+	__IOM uint32_t MCONFIG; /*!< (@ 0x0014) SPISLV Memory Config */
+	__IOM uint32_t MBA0; /*!< (@ 0x0018) SPISLV Memory Base Address 0 */
+	__IOM uint32_t MBA0_WLIM; /*!< (@ 0x001C) SPISLV Memory Base Address 0 Write Limit */
+	__IOM uint32_t MBA0_RLIM; /*!< (@ 0x0020) SPISLV Memory Base Address 0 Read Limit */
+	__IOM uint32_t MBA1; /*!< (@ 0x0024) SPISLV Memory Base Address 1 */
+	__IOM uint32_t MBA1_WLIM; /*!< (@ 0x0028) SPISLV Memory Base Address 0 Write Limit */
+	__IOM uint32_t MBA1_RLIM; /*!< (@ 0x002C) SPISLV Memory Base Address 0 Read Limit */
+	__IOM uint32_t RXF_HBAR; /*!< (@ 0x0030) SPISLV RX FIFO Host BAR */
+	__IOM uint32_t RXF_BCNT; /*!< (@ 0x0034) SPISLV RX FIFO Byte Counter */
+	__IOM uint32_t TXF_HBAR; /*!< (@ 0x0038) SPISLV RX FIFO Host BAR */
+	__IOM uint32_t TXF_BCNT; /*!< (@ 0x003C) SPISLV TX FIFO Byte Counter */
+	__IOM uint32_t SYS_CONFIG; /*!< (@ 0x0040) SPISLV System Config */
+	__IOM uint32_t MBOX_S2EC; /*!< (@ 0x0044) SPISLV SPI Master to EC Mailbox */
+	__IOM uint32_t MBOX_EC2S; /*!< (@ 0x0048) SPISLV EC to SPI Master Mailbox */
+} SPISLV_Type;
+
+#endif	/* #ifndef _SPI_SLAVE_H */
+/* end spi_slave.h */
+/**   @}
+ */

--- a/mec/mec1501/component/tach.h
+++ b/mec/mec1501/component/tach.h
@@ -1,0 +1,171 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file tach.h
+ *MEC1501 Tachometer registers
+ */
+/** @defgroup MEC1501 Peripherals TACH
+ */
+
+#ifndef _TACH_H
+#define _TACH_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		 TACH 				=========== */
+/* =========================================================================*/
+
+#define MCHP_TACH_BASE_ADDR		0x40006000ul
+
+#define MCHP_TACH_MAX_INSTANCES		4u
+#define MCHP_TACH_INST_SPACING		0x10ul
+#define MCHP_TACH_INST_SPACING_P2	4u
+
+#define MCHP_TACH_ADDR(n)		(MCHP_TACH_BASE_ADDR + \
+					 ((n) << MCHP_TACH_INST_SPACING_P2))
+
+/*
+ * TACH interrupts
+ */
+#define MCHP_TACH0_GIRQ		17u
+#define MCHP_TACH1_GIRQ		17u
+#define MCHP_TACH2_GIRQ		17u
+#define MCHP_TACH3_GIRQ		17u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_TACH0_GIRQ_POS	1u
+#define MCHP_TACH1_GIRQ_POS	2u
+#define MCHP_TACH2_GIRQ_POS	3u
+#define MCHP_TACH3_GIRQ_POS	4u
+
+#define MCHP_TACH0_GIRQ_VAL	(1ul << MCHP_TACH0_GIRQ_POS)
+#define MCHP_TACH1_GIRQ_VAL	(1ul << MCHP_TACH1_GIRQ_POS)
+#define MCHP_TACH2_GIRQ_VAL	(1ul << MCHP_TACH2_GIRQ_POS)
+#define MCHP_TACH3_GIRQ_VAL	(1ul << MCHP_TACH3_GIRQ_POS)
+
+/* TACH GIRQ aggregated NVIC input */
+#define MCHP_TACH0_NVIC_AGGR	9u
+#define MCHP_TACH1_NVIC_AGGR	9u
+#define MCHP_TACH2_NVIC_AGGR	9u
+#define MCHP_TACH3_NVIC_AGGR	9u
+
+/* TACH direct NVIC inputs */
+#define MCHP_TACH0_NVIC_DIRECT	71u
+#define MCHP_TACH1_NVIC_DIRECT	72u
+#define MCHP_TACH2_NVIC_DIRECT	73u
+#define MCHP_TACH3_NVIC_DIRECT	159u
+
+/*
+ * TACH Control register
+ */
+#define MCHP_TACH_CONTROL_REG_OFS		0U
+#define MCHP_TACH_CONTROL_MASK			0xffffdd03U
+/* Enable exceed high or low limit detection */
+#define MCHP_TACH_CTRL_EXCEED_LIM_EN_POS	0
+#define MCHP_TACH_CTRL_EXCEED_LIM_EN	\
+		(1ul << MCHP_TACH_CTRL_EXCEED_LIM_EN_POS)
+/* Enable TACH operation */
+#define MCHP_TACH_CTRL_EN_POS		1
+#define MCHP_TACH_CTRL_EN		(1ul << MCHP_TACH_CTRL_EN_POS)
+/* Enable input filter */
+#define MCHP_TACH_CTRL_FILTER_EN_POS	8
+#define MCHP_TACH_CTRL_FILTER_EN	(1ul << MCHP_TACH_CTRL_FILTER_EN_POS)
+/* Select read mode. Latch data on rising edge of selected trigger */
+#define MCHP_TACH_CTRL_READ_MODE_SEL_POS	10
+#define MCHP_TACH_CTRL_READ_MODE_INPUT	\
+		(0ul << MCHP_TACH_READ_MODE_SEL_POS)
+#define MCHP_TACH_CTRL_READ_MODE_100K_CLOCK	\
+		(1ul << MCHP_TACH_READ_MODE_SEL_POS)
+/* Select TACH edges for counter increment */
+#define MCHP_TACH_CTRL_NUM_EDGES_POS	11
+#define MCHP_TACH_CTRL_NUM_EDGES_MASK0	0x03U
+#define MCHP_TACH_CTRL_NUM_EDGES_MASK	(MCHP_TACH_CTRL_NUM_EDGES_MASK0 \
+					 << MCHP_TACH_CTRL_NUM_EDGES_POS)
+#define MCHP_TACH_CTRL_EDGES_2	(0ul << MCHP_TACH_CTRL_NUM_EDGES_POS)
+#define MCHP_TACH_CTRL_EDGES_3	(1ul << MCHP_TACH_CTRL_NUM_EDGES_POS)
+#define MCHP_TACH_CTRL_EDGES_5	(2ul << MCHP_TACH_CTRL_NUM_EDGES_POS)
+#define MCHP_TACH_CTRL_EDGES_9	(3ul << MCHP_TACH_CTRL_NUM_EDGES_POS)
+/* Enable count ready interrupt */
+#define MCHP_TACH_CTRL_CNT_RDY_INT_EN_POS	14
+#define MCHP_TACH_CTRL_CNT_RDY_INT_EN	\
+	(1ul << MCHP_TACH_CTRL_CNT_RDY_INT_EN_POS)
+/* Enable input toggle interrupt */
+#define MCHP_TACH_CTRL_TOGGLE_INT_EN_POS	15
+#define MCHP_TACH_CTRL_TOGGLE_INT_EN	\
+	(1ul << MCHP_TACH_CTRL_TOGGLE_INT_EN_POS)
+/* Read-only latched TACH pulse counter */
+#define MCHP_TACH_CTRL_COUNTER_POS	16
+#define MCHP_TACH_CTRL_COUNTER_MASK0	0xfffful
+#define MCHP_TACH_CTRL_COUNTER_MASK	\
+	(MCHP_TACH_CTRL_COUNTER_MASK0 << MCHP_TACH_CTRL_COUNTER_POS)
+
+/*
+ * TACH Status register
+ * bits[0, 2-3] are R/W1C
+ * bit[1] is Read-Only
+ */
+#define MCHP_TACH_STATUS_REG_OFS	4U
+#define MCHP_TACH_STATUS_MASK		0x0FU
+#define MCHP_TACH_STS_EXCEED_LIMIT_POS	0
+#define MCHP_TACH_STS_EXCEED_LIMIT	(1U << MCHP_TACH_STS_EXCEED_LIMIT_POS)
+#define MCHP_TACH_STS_PIN_STATE_POS	1
+#define MCHP_TACH_STS_PIN_STATE_HI	(1U << MCHP_TACH_STS_PIN_STATE_POS)
+#define MCHP_TACH_STS_TOGGLE_POS	2
+#define MCHP_TACH_STS_TOGGLE		(1U << MCHP_TACH_STS_TOGGLE_POS)
+#define MCHP_TACH_STS_CNT_RDY_POS	3
+#define MCHP_TACH_STS_CNT_RDY		(1U << MCHP_TACH_STS_CNT_RDY_POS)
+
+/*
+ * TACH High Limit Register
+ */
+#define MCHP_TACH_HI_LIMIT_REG_OFS	8U
+#define MCHP_TACH_HI_LIMIT_MASK		0xffffU
+
+/*
+ * TACH Low Limit Register
+ */
+#define MCHP_TACH_LO_LIMIT_REG_OFS	0x0CU
+#define MCHP_TACH_LO_LIMIT_MASK		0xffffU
+
+
+/**
+  * @brief Tachometer Registers (TACH)
+  */
+typedef struct tach_regs {
+	__IOM uint32_t CONTROL;	/*!< (@ 0x0000) TACH Control b[31:0] */
+	__IOM uint32_t STATUS;	/*!< (@ 0x0004) TACH Status b[7:0] */
+	__IOM uint32_t LIMIT_HI; /*!< (@ 0x0008) TACH High LImit b[15:0] */
+	__IOM uint32_t LIMIT_LO; /*!< (@ 0x000C) TACH Low Limit b[15:0] */
+} TACH_Type;
+
+#endif	/* #ifndef _TACH_H */
+/* end tach.h */
+/**   @}
+ */

--- a/mec/mec1501/component/vbat.h
+++ b/mec/mec1501/component/vbat.h
@@ -116,8 +116,7 @@
 /**
   * @brief VBAT Register Bank (VBATR)
   */
-typedef struct vbatr_regs
- {		/*!< (@ 0x4000A400) VBATR Structure   */
+typedef struct vbatr_regs {
 	__IOM uint32_t PFRS;	/*! (@ 0x00000000) VBATR Power Fail Reset Status */
 	uint8_t RSVD1[4];
 	__IOM uint32_t CLK32_EN;	/*! (@ 0x00000008) VBATR 32K clock enable */
@@ -137,14 +136,163 @@ typedef struct vbatr_regs
   */
 #define MCHP_VBAT_MEM_LEN	64ul
 
-typedef struct vbatm_regs
- {		/*!< (@ 0x4000A800) VBATM Structure   */
+typedef struct vbatm_regs {
 	union vbmem_u {
 		uint32_t u32[(MCHP_VBAT_MEM_LEN) / 4];
 		uint16_t u16[(MCHP_VBAT_MEM_LEN) / 2];
 		uint8_t u8[MCHP_VBAT_MEM_LEN];
 	} MEM;
 } VBATM_Type;
+
+/* =========================================================================*/
+/* ================		 VCI 			=================== */
+/* =========================================================================*/
+
+#define MCHP_VCI_BASE_ADDR	0x4000AE00ul
+
+/*
+ * VCI interrupts
+ */
+#define MCHP_VCI_OVRD_GIRQ	21u
+#define MCHP_VCI_IN0_GIRQ	21u
+#define MCHP_VCI_IN1_GIRQ	21u
+#define MCHP_VCI_IN2_GIRQ	21u
+#define MCHP_VCI_IN3_GIRQ	21u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_VCI_OVRD_GIRQ_POS	10u
+#define MCHP_VCI_IN0_GIRQ_POS	11u
+#define MCHP_VCI_IN1_GIRQ_POS	12u
+#define MCHP_VCI_IN2_GIRQ_POS	13u
+#define MCHP_VCI_IN3_GIRQ_POS	14u
+
+#define MCHP_VCI_OVRD_GIRQ_VAL	(1ul << MCHP_VCI_OVRD_GIRQ_POS)
+#define MCHP_VCI_IN0_GIRQ_VAL	(1ul << MCHP_VCI_IN0_GIRQ_POS)
+#define MCHP_VCI_IN1_GIRQ_VAL	(1ul << MCHP_VCI_IN1_GIRQ_POS)
+#define MCHP_VCI_IN2_GIRQ_VAL	(1ul << MCHP_VCI_IN2_GIRQ_POS)
+#define MCHP_VCI_IN3_GIRQ_VAL	(1ul << MCHP_VCI_IN3_GIRQ_POS)
+
+/* VCI GIRQ aggregated NVIC input */
+#define MCHP_VCI_OVRD_NVIC_AGGR	13u
+#define MCHP_VCI_IN0_NVIC_AGGR	13u
+#define MCHP_VCI_IN1_NVIC_AGGR	13u
+#define MCHP_VCI_IN2_NVIC_AGGR	13u
+#define MCHP_VCI_IN3_NVIC_AGGR	13u
+
+/* VCI direct NVIC inputs */
+#define MCHP_VCI_OVRD_NVIC_DIRECT	121u
+#define MCHP_VCI_IN0_NVIC_DIRECT	122u
+#define MCHP_VCI_IN1_NVIC_DIRECT	123u
+#define MCHP_VCI_IN2_NVIC_DIRECT	124u
+#define MCHP_VCI_IN3_NVIC_DIRECT	125u
+
+/* VCI Config register */
+#define MCHP_VCI_CFG_REG_OFS		0
+#define MCHP_VCI_CFG_REG_MASK		0x00071F8Ful
+#define MCHP_VCI_CFG_IN03_MASK		0x0Fu
+#define MCHP_VCI_CFG_IN0_HI		0x01u
+#define MCHP_VCI_CFG_IN1_HI		0x02u
+#define MCHP_VCI_CFG_IN2_HI		0x04u
+#define MCHP_VCI_CFG_IN3_HI		0x08u
+#define MCHP_VCI_CFG_VPWR_POS		7
+#define MCHP_VCI_CFG_VPWR_VTR		(0ul << 7)
+#define MCHP_VCI_CFG_VPWR_VBAT		(1ul << 7)
+#define MCHP_VCI_VCI_OVRD_IN_PIN	(1ul << 8)
+#define MCHP_VCI_VCI_OUT_PIN		(1ul << 9)
+#define MCHP_VCI_FW_CTRL_EN		(1ul << 10)
+#define MCHP_VCI_FW_EXT_SEL		(1ul << 11)
+#define MCHP_VCI_FILTER_BYPASS		(1ul << 12)
+#define MCHP_VCI_WEEK_ALARM		(1ul << 16)
+#define MCHP_VCI_RTC_ALARM		(1ul << 17)
+#define MCHP_VCI_SYS_PWR_PRES		(1ul << 18)
+
+/* VCI Latch Enable register */
+#define MCHP_VCI_LE_REG_OFS		4
+#define MCHP_VCI_LE_REG_MASK		0x0003000Ful
+#define MCHP_VCI_LE_IN03_MASK		0x0Fu
+#define MCHP_VCI_LE_IN0			0x01u
+#define MCHP_VCI_LE_IN1			0x02u
+#define MCHP_VCI_LE_IN2			0x04u
+#define MCHP_VCI_LE_IN3			0x08u
+#define MCHP_VCI_LE_WEEK_ALARM		(1ul << 16)
+#define MCHP_VCI_LE_RTC_ALARM		(1ul << 17)
+
+/* VCI Latch Resets register */
+#define MCHP_VCI_LR_REG_OFS		8
+#define MCHP_VCI_LR_REG_MASK		0x0003000Ful
+#define MCHP_VCI_LR_IN03_MASK		0x0Fu
+#define MCHP_VCI_LR_IN0			0x01u
+#define MCHP_VCI_LR_IN1			0x02u
+#define MCHP_VCI_LR_IN2			0x04u
+#define MCHP_VCI_LR_IN3			0x08u
+#define MCHP_VCI_LR_WEEK_ALARM		(1ul << 16)
+#define MCHP_VCI_LR_RTC_ALARM		(1ul << 17)
+
+/* VCI Input Enable register */
+#define MCHP_VCI_INPUT_EN_REG_OFS	0x0C
+#define MCHP_VCI_INPUT_EN_REG_MASK	0x0Ful
+#define MCHP_VCI_INPUT_EN_IE30_MASK	0x0Fu
+#define MCHP_VCI_INPUT_EN_IN0		0x01u
+#define MCHP_VCI_INPUT_EN_IN1		0x02u
+#define MCHP_VCI_INPUT_EN_IN2		0x04u
+#define MCHP_VCI_INPUT_EN_IN3		0x08u
+
+/* VCI Hold Off Count register */
+#define MCHP_VCI_HDO_REG_OFS		0x10
+#define MCHP_VCI_HDO_REG_MASK		0xFFul
+
+/* VCI Polarity register */
+#define MCHP_VCI_POL_REG_OFS		0x14
+#define MCHP_VCI_POL_REG_MASK		0x0Ful
+#define MCHP_VCI_POL_IE30_MASK		0x0Fu
+#define MCHP_VCI_POL_ACT_HI_IN0		0x01u
+#define MCHP_VCI_POL_ACT_HI_IN1		0x02u
+#define MCHP_VCI_POL_ACT_HI_IN2		0x04u
+#define MCHP_VCI_POL_ACT_HI_IN3		0x08u
+
+/* VCI Positive Edge Detect register */
+#define MCHP_VCI_PDET_REG_OFS		0x18
+#define MCHP_VCI_PDET_REG_MASK		0x0Ful
+#define MCHP_VCI_PDET_IE30_MASK		0x0Fu
+#define MCHP_VCI_PDET_IN0		0x01u
+#define MCHP_VCI_PDET_IN1		0x02u
+#define MCHP_VCI_PDET_IN2		0x04u
+#define MCHP_VCI_PDET_IN3		0x08u
+
+/* VCI Positive Edge Detect register */
+#define MCHP_VCI_NDET_REG_OFS		0x1C
+#define MCHP_VCI_NDET_REG_MASK		0x0Ful
+#define MCHP_VCI_NDET_IE30_MASK		0x0Fu
+#define MCHP_VCI_NDET_IN0		0x01u
+#define MCHP_VCI_NDET_IN1		0x02u
+#define MCHP_VCI_NDET_IN2		0x04u
+#define MCHP_VCI_NDET_IN3		0x08u
+
+/* VCI Buffer Enable register */
+#define MCHP_VCI_BEN_REG_OFS		0x20
+#define MCHP_VCI_BEN_REG_MASK		0x0Ful
+#define MCHP_VCI_BEN_IE30_MASK		0x0Fu
+#define MCHP_VCI_BEN_IN0		0x01u
+#define MCHP_VCI_BEN_IN1		0x02u
+#define MCHP_VCI_BEN_IN2		0x04u
+#define MCHP_VCI_BEN_IN3		0x08u
+
+/**
+  * @brief VBAT powered control interface (VCI)
+  */
+
+typedef struct vci_regs {
+	__IOM uint32_t CONFIG; /*! (@ 0x0000) VCI Config register */
+	__IOM uint32_t LATCH_EN; /*! (@ 0x0004) VCI Latch enable register */
+	__IOM uint32_t LATCH_RST; /*! (@ 0x0008) VCI Latch resets register */
+	__IOM uint32_t INPUT_EN; /*! (@ 0x000C) VCI Input enable register */
+	__IOM uint32_t HOLD_OFF; /*! (@ 0x0010) VCI Hold off count register */
+	__IOM uint32_t POLARITY; /*! (@ 0x0014) VCI Polarity register */
+	__IOM uint32_t PEDGE_DET; /*! (@ 0x0018) VCI Positive edge detect register */
+	__IOM uint32_t NEDGE_DET; /*! (@ 0x001C) VCI Negative edge detect register */
+	__IOM uint32_t BUFFER_EN; /*! (@ 0x0020) VCI Buffer enable register */
+} VCI_Type;
+
 
 #endif	/* #ifndef _VBAT_H */
 /* end vbat.h */

--- a/mec/mec1501/component/wdt.h
+++ b/mec/mec1501/component/wdt.h
@@ -39,56 +39,97 @@
 #include "regaccess.h"
 
 /* =========================================================================*/
-/* ================   WDT				   ================ */
+/* ================		  WDT  			====================*/
 /* =========================================================================*/
 
 #define MCHP_WDT_BASE_ADDR		0x40000400ul
 
-#define MCHP_WDT_CTRL_MASK		0x021Dul
+/* WDT Interrupt */
+#define MCHP_WDT_GIRQ			21u
+#define MCHP_WDT_GIRQ_NVIC		13u
+#define MCHP_WDT_GIRQ_NVIC_DIRECT	171u
+
+/* Bit position in Interrupt Aggregator GIRQ registers */
+#define MCHP_WDT_GIRQ_POS		2u
+
+/* Interrupt Aggregator Source, Enable Set/Clear registers value */
+#define MCHP_WDT_GIRQ_VAL		(1ul << MCHP_WDT_GIRQ_POS)
+
+
+/* Load register */
+#define MCHP_WDT_LOAD_REG_OFS		0x00ul
+#define MCHP_WDT_LOAD_REG_MASK		0xFFFFul
+
+/* Control register */
+#define MCHP_WDT_CTRL_REG_OFS		0x04ul
+#define MCHP_WDT_CTRL_REG_MASK		0x021Dul
 #define MCHP_WDT_CTRL_EN_POS		0u
-#define MCHP_WDT_CTRL_EN_MASK		(1u1 << (MCHP_WDT_CTRL_EN_POS))
-#define MCHP_WDT_CTRL_EN		(1u1 << (MCHP_WDT_CTRL_EN_POS))
+#define MCHP_WDT_CTRL_EN_MASK		(1ul << MCHP_WDT_CTRL_EN_POS)
+#define MCHP_WDT_CTRL_EN		(1ul << MCHP_WDT_CTRL_EN_POS)
 #define MCHP_WDT_CTRL_HTMR_STALL_POS	2u
-#define MCHP_WDT_CTRL_HTMR_STALL_MASK	(1u1 << (MCHP_WDT_CTRL_HTMR_STALL_POS))
-#define MCHP_WDT_CTRL_HTMR_STALL_EN	(1u1 << (MCHP_WDT_CTRL_HTMR_STALL_POS))
+#define MCHP_WDT_CTRL_HTMR_STALL_MASK	(1ul << MCHP_WDT_CTRL_HTMR_STALL_POS)
+#define MCHP_WDT_CTRL_HTMR_STALL_EN	(1ul << MCHP_WDT_CTRL_HTMR_STALL_POS)
 #define MCHP_WDT_CTRL_WKTMR_STALL_POS	3u
-#define MCHP_WDT_CTRL_WKTMR_STALL_MASK	(1u1 << (MCHP_WDT_CTRL_WKTMR_STALL_POS))
-#define MCHP_WDT_CTRL_WKTMR_STALL_EN	(1u1 << (MCHP_WDT_CTRL_WKTMR_STALL_POS))
+#define MCHP_WDT_CTRL_WKTMR_STALL_MASK	(1ul << MCHP_WDT_CTRL_WKTMR_STALL_POS)
+#define MCHP_WDT_CTRL_WKTMR_STALL_EN	(1ul << MCHP_WDT_CTRL_WKTMR_STALL_POS)
 #define MCHP_WDT_CTRL_JTAG_STALL_POS	4u
-#define MCHP_WDT_CTRL_JTAG_STALL_MASK	(1u1 << (MCHP_WDT_CTRL_JTAG_STALL_POS))
-#define MCHP_WDT_CTRL_JTAG_STALL_EN	(1u1 << (MCHP_WDT_CTRL_JTAG_STALL_POS))
+#define MCHP_WDT_CTRL_JTAG_STALL_MASK	(1ul << MCHP_WDT_CTRL_JTAG_STALL_POS)
+#define MCHP_WDT_CTRL_JTAG_STALL_EN	(1ul << MCHP_WDT_CTRL_JTAG_STALL_POS)
+/*
+ * WDT mode selecting action taken upon count expiration.
+ * 0 = Generate chip reset
+ * 1 = Clear this bit,
+ *     Set event status
+ *     Generate interrupt if event IEN bit is set
+ *     Kick WDT causing it to reload from LOAD register
+ * If interrupt is enabled in GIRQ21 and NVIC then the EC will jump
+ * to the WDT ISR.
+ */
+#define MCHP_WDT_CTRL_MODE_POS		9u
+#define MCHP_WDT_CTRL_MODE_MASK		(1ul << MCHP_WDT_CTRL_MODE_POS)
+#define MCHP_WDT_CTRL_MODE_RESET	(0ul << MCHP_WDT_CTRL_MODE_POS)
+#define MCHP_WDT_CTRL_MODE_IRQ		(1ul << MCHP_WDT_CTRL_MODE_POS)
 
 /* WDT Kick register. Write any value to reload counter */
-#define MCHP_WDT_KICK_OFS		0x08ul
+#define MCHP_WDT_KICK_REG_OFS		0x08ul
+#define MCHP_WDT_KICK_REG_MASK		0xFFul
+#define MCHP_WDT_KICK_VAL		0
 
 /* WDT Count register. Read only */
-#define MCHP_WDT_CNT_RO_OFS		0x0Cul
-#define MCHP_WDT_CNT_RO_MASK		0xFFFFul
+#define MCHP_WDT_CNT_RO_REG_OFS		0x0Cul
+#define MCHP_WDT_CNT_RO_REG_MASK	0xFFFFul
 
-/*
- * If this bit is set when the WDT counts down it will clear this
- * bit, fire an interrupt if IEN is enabled, and start counting up.
- * Once it reaches maximum count it actives its reset output.
- * This feature allows WDT ISR time to take action before WDT asserts
- * its reset signal.
- * If this bit is clear WDT will immediately assert its reset signal
- * when counter counts down to 0.
- */
-#define WDT_CTRL_INH1_POS	9u
-#define WDT_CTRL_INH1_MASK	(1u1 << (WDT_CTRL_INH1_POS))
-#define WDT_CTRL_INH1_EN	(1u1 << (WDT_CTRL_INH1_POS))
+/* Status Register */
+#define MCHP_WDT_STS_REG_OFS		0x10ul
+#define MCHP_WDT_STS_REG_MASK		0x01ul
+#define MCHP_WDT_STS_EVENT_IRQ_POS	0u
+#define MCHP_WDT_STS_EVENT_IRQ		(1ul << MCHP_WDT_STS_EVENT_IRQ_POS)
 
 /* Interrupt Enable Register */
-#define WDT_IEN_MASK		0x01ul
-#define WDT_IEN_EVENT_IRQ_POS	0u
-#define WDT_IEN_EVENT_IRQ_MASK	(1ul << (WDT_IEN_EVENT_IRQ_POS))
-#define WDT_IEN_EVENT_IRQ_EN	(1ul << (WDT_IEN_EVENT_IRQ_POS))
+#define MCHP_WDT_IEN_REG_OFS		0x14ul
+#define MCHP_WDT_IEN_REG_MASK		0x01ul
+#define MCHP_WDT_IEN_EVENT_IRQ_POS	0u
+#define MCHP_WDT_IEN_EVENT_IRQ_MASK	(1ul << (MCHP_WDT_IEN_EVENT_IRQ_POS))
+#define MCHP_WDT_IEN_EVENT_IRQ_EN	(1ul << (MCHP_WDT_IEN_EVENT_IRQ_POS))
+
+/* Register access */
+#define MCHP_WDT_LOAD_REG_ADDR	(MCHP_WDT_BASE_ADDR + MCHP_WDT_LOAD_REG_OFS)
+#define MCHP_WDT_CTRL_REG_ADDR	(MCHP_WDT_BASE_ADDR + MCHP_WDT_CTRL_REG_OFS)
+#define MCHP_WDT_KICK_REG_ADDR	(MCHP_WDT_BASE_ADDR + MCHP_WDT_KICK_REG_OFS)
+#define MCHP_WDT_STS_REG_ADDR	(MCHP_WDT_BASE_ADDR + MCHP_WDT_STS_REG_OFS)
+#define MCHP_WDT_IEN_REG_ADDR	(MCHP_WDT_BASE_ADDR + MCHP_WDT_IEN_REG_OFS)
+
+#define MCHP_WDT_LOAD()		REG16(MCHP_WDT_LOAD_REG_ADDR)
+#define MCHP_WDT_CTRL()		REG16(MCHP_WDT_CTRL_REG_ADDR)
+#define MCHP_WDT_KICK()		REG8(MCHP_WDT_KICK_REG_ADDR)
+#define MCHP_WDT_CNT()		REG16(MCHP_WDT_CNT_REG_ADDR)
+#define MCHP_WDT_STS()		REG8(MCHP_WDT_STS_REG_ADDR)
+#define MCHP_WDT_IEN()		REG8(MCHP_WDT_IEN_REG_ADDR)
 
 /**
   * @brief Watch Dog Timer (WDT)
   */
-typedef struct wdt_regs
- {
+typedef struct wdt_regs {
 	__IOM uint16_t LOAD;	/*!< (@ 0x00000000) WDT Load	 */
 	uint8_t RSVD1[2];
 	__IOM uint16_t CTRL;	/*!< (@ 0x00000004) WDT Control	 */
@@ -99,7 +140,7 @@ typedef struct wdt_regs
 	uint8_t RSVD4[2];
 	__IOM uint16_t STS;	/*!< (@ 0x00000010) WDT Status	*/
 	uint8_t RSVD5[2];
-	__IOM uint8_t IEN;	/*!< (@ 0x00000010) WDT Interrupt Enable  */
+	__IOM uint8_t IEN;	/*!< (@ 0x00000014) WDT Interrupt Enable  */
 } WDT_Type;
 
 #endif	/* #ifndef _WDT_H */


### PR DESCRIPTION
Added the missing peripheral header files to the MEC1501 HAL.
The added peripherals are: ACPI PM1, ADC, HDMI_CEC, PECI,
PROCHOT, PWM, RTC, SPI slave, TACH, VBAT VCI. Cleaned up WDT
defines.

Signed-off-by: Scott Worley <scott.worley@microchip.com>