### PR TITLE
modules: Add eSPI SAF header and updates

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,3 +7,10 @@ sed -i -e 's/[ \t\r]*$//g' MCHP_MEC1701_bit_fields.h, then file was renamed
 to MCHP_MEC1701.h
 
 Field EOF was renamed to PEOF as it was collapsing with EOF defined in stdio.h
+
+Microchip HAL contianing the above MEC1701 single header and the 
+MEC1501 component style is located at:
+
+https://github.com/MicrochipTech/hal_microchip
+
+Version: 1.1.0

--- a/mec/mec1501/MEC1501hsz.h
+++ b/mec/mec1501/MEC1501hsz.h
@@ -439,6 +439,7 @@ typedef enum IRQn {
 #include "component/emi.h"
 #include "component/espi_io.h"
 #include "component/espi_mem.h"
+#include "component/espi_saf.h"
 #include "component/espi_vw.h"
 #include "component/global_cfg.h"
 #include "component/hdmi_cec.h"
@@ -610,8 +611,10 @@ typedef enum IRQn {
 #define ESPI_MEM_EBAR_REGS  ((ESPI_MEM_BAR_EC_Type *)(ESPI_MEM_EC_BAR_BASE))
 #define ESPI_MEM_HBAR_REGS  ((ESPI_MEM_BAR_HOST_Type *)(ESPI_MEM_HOST_BAR_BASE))
 
-#define ESPI_MEM_SRAM_EBAR_REGS   ((ESPI_MEM_SRAM_BAR_EC_Type *)(ESPI_MEM_SRAM_EC_BAR_BASE))
-#define ESPI_MEM_SRAM_HBAR_REGS   ((ESPI_MEM_SRAM_BAR_HOST_Type *)(ESPI_MEM_SRAM_HOST_BAR_BASE))
+#define ESPI_MEM_SRAM_EBAR_REGS \
+	((ESPI_MEM_SRAM_BAR_EC_Type *)(ESPI_MEM_SRAM_EC_BAR_BASE))
+#define ESPI_MEM_SRAM_HBAR_REGS \
+	((ESPI_MEM_SRAM_BAR_HOST_Type *)(ESPI_MEM_SRAM_HOST_BAR_BASE))
 
 #define ESPI_MEM_BM_REGS  ((ESPI_MEM_BM_Type *)(ESPI_MEM_BM_BASE))
 

--- a/mec/mec1501/component/espi_io.h
+++ b/mec/mec1501/component/espi_io.h
@@ -42,6 +42,15 @@
 
 #define MCHP_ESPI_IO_BASE_ADDR	0x400F3400ul
 
+/* Offsets from base for various register groups */
+#define MCHP_ESPI_IO_PC_OFS 0x0100ul
+#define MCHP_ESPI_IO_HOST_BAR_OFS 0x0120ul
+#define MCHP_ESPI_IO_LTR_OFS 0x0220ul
+#define MCHP_ESPI_IO_OOB_OFS 0x0240ul
+#define MCHP_ESPI_IO_FC_OFS 0x0280ul
+#define MCHP_ESPI_IO_CAP_OFS 0x02b0ul
+#define MCHP_ESPI_IO_SIRQ_OFS 0x03a0ul
+
 /*
  * ESPI IO Component interrupts
  */
@@ -76,27 +85,27 @@
  * GIRQ19 cannot be configured for direct mode unless
  * SAF interrupt are not used.
  */
-#define MCHP_ESPI_SAF_DONE_GIRQ_POS	9u	/* No direct NVIC connection */
-#define MCHP_ESPI_SAF_ERR_GIRQ_POS	10u	/* No direct NVIC connection */
+#define MCHP_ESPI_SAF_DONE_GIRQ_POS	9u
+#define MCHP_ESPI_SAF_ERR_GIRQ_POS	10u
 
-#define MCHP_ESPI_PC_GIRQ_VAL		(1ul << 0)
-#define MCHP_ESPI_BM1_GIRQ_VAL		(1ul << 1)
-#define MCHP_ESPI_BM2_GIRQ_VAL		(1ul << 2)
-#define MCHP_ESPI_LTR_GIRQ_VAL		(1ul << 3)
-#define MCHP_ESPI_OOB_UP_GIRQ_VAL	(1ul << 4)
-#define MCHP_ESPI_OOB_DN_GIRQ_VAL	(1ul << 5)
-#define MCHP_ESPI_FC_GIRQ_VAL		(1ul << 6)
-#define MCHP_ESPI_ESPI_RST_GIRQ_VAL	(1ul << 7)
-#define MCHP_ESPI_VW_EN_GIRQ_VAL	(1ul << 8)
-#define MCHP_ESPI_SAF_DONE_GIRQ_VAL	(1ul << 9)
-#define MCHP_ESPI_SAF_ERR_GIRQ_VAL	(1ul << 10)
+#define MCHP_ESPI_PC_GIRQ_VAL		BIT(0)
+#define MCHP_ESPI_BM1_GIRQ_VAL		BIT(1)
+#define MCHP_ESPI_BM2_GIRQ_VAL		BIT(2)
+#define MCHP_ESPI_LTR_GIRQ_VAL		BIT(3)
+#define MCHP_ESPI_OOB_UP_GIRQ_VAL	BIT(4)
+#define MCHP_ESPI_OOB_DN_GIRQ_VAL	BIT(5)
+#define MCHP_ESPI_FC_GIRQ_VAL		BIT(6)
+#define MCHP_ESPI_ESPI_RST_GIRQ_VAL	BIT(7)
+#define MCHP_ESPI_VW_EN_GIRQ_VAL	BIT(8)
+#define MCHP_ESPI_SAF_DONE_GIRQ_VAL	BIT(9)
+#define MCHP_ESPI_SAF_ERR_GIRQ_VAL	BIT(10)
 
 /* eSPI Global Capabilities 0 */
 #define MCHP_ESPI_GBL_CAP0_MASK		0x0Fu
-#define MCHP_ESPI_GBL_CAP0_PC_SUPP	(1u << 0)
-#define MCHP_ESPI_GBL_CAP0_VW_SUPP	(1u << 1)
-#define MCHP_ESPI_GBL_CAP0_OOB_SUPP	(1u << 2)
-#define MCHP_ESPI_GBL_CAP0_FC_SUPP	(1u << 3)
+#define MCHP_ESPI_GBL_CAP0_PC_SUPP	BIT(0)
+#define MCHP_ESPI_GBL_CAP0_VW_SUPP	BIT(1)
+#define MCHP_ESPI_GBL_CAP0_OOB_SUPP	BIT(2)
+#define MCHP_ESPI_GBL_CAP0_FC_SUPP	BIT(3)
 
 /* eSPI Global Capabilities 1 */
 #define MCHP_ESPI_GBL_CAP1_MASK			0xFFu
@@ -114,20 +123,20 @@
 	(0u << (MCHP_ESPI_GBL_CAP1_ALERT_POS))
 #define MCHP_ESPI_GBL_CAP1_IO_MODE_POS		4u
 #define MCHP_ESPI_GBL_CAP1_IO_MODE_MASK0	0x03u
-#define MCHP_ESPI_GBL_CAP1_IO_MODE_MASK \
-	((MCHP_ESPI_GBL_CAP1_IO_MODE_MASK0) << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_MASK ((MCHP_ESPI_GBL_CAP1_IO_MODE_MASK0) \
+					 << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
 #define MCHP_ESPI_GBL_CAP1_IO_MODE0_1		0u
 #define MCHP_ESPI_GBL_CAP1_IO_MODE0_12		1u
 #define MCHP_ESPI_GBL_CAP1_IO_MODE0_14		2u
 #define MCHP_ESPI_GBL_CAP1_IO_MODE0_124		3u
-#define MCHP_ESPI_GBL_CAP1_IO_MODE_1 \
-	((MCHP_ESPI_GBL_CAP1_IO_MODE0_1) << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
-#define MCHP_ESPI_GBL_CAP1_IO_MODE_12 \
-	((MCHP_ESPI_GBL_CAP1_IO_MODE0_12) << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
-#define MCHP_ESPI_GBL_CAP1_IO_MODE_14 \
-	((MCHP_ESPI_GBL_CAP1_IO_MODE0_14) << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
-#define MCHP_ESPI_GBL_CAP1_IO_MODE_124 \
-	((MCHP_ESPI_GBL_CAP1_IO_MODE0_124) << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_1 ((MCHP_ESPI_GBL_CAP1_IO_MODE0_1) \
+				      << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_12 ((MCHP_ESPI_GBL_CAP1_IO_MODE0_12) \
+				       << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_14 ((MCHP_ESPI_GBL_CAP1_IO_MODE0_14) \
+				       << (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_124 ((MCHP_ESPI_GBL_CAP1_IO_MODE0_124) \
+					<< (MCHP_ESPI_GBL_CAP1_IO_MODE_POS))
 /*
  * Support Open Drain ALERT pin configuration
  * EC sets this bit if it can support open-drain ESPI_ALERT#
@@ -170,8 +179,8 @@
 #define MCHP_ESPI_FC_CAP_MAX_PLD_SZ_64		0x01u
 #define MCHP_ESPI_FC_CAP_SHARE_POS		3u
 #define MCHP_ESPI_FC_CAP_SHARE_MASK0		0x03u
-#define MCHP_ESPI_FC_CAP_SHARE_MASK \
-	((MCHP_ESPI_FC_CAP_SHARE_MASK0) << (MCHP_ESPI_FC_CAP_SHARE_POS))
+#define MCHP_ESPI_FC_CAP_SHARE_MASK ((MCHP_ESPI_FC_CAP_SHARE_MASK0) \
+				     << (MCHP_ESPI_FC_CAP_SHARE_POS))
 #define MCHP_ESPI_FC_CAP_SHARE_MAF_ONLY \
 	(0u << (MCHP_ESPI_FC_CAP_SHARE_POS))
 #define MCHP_ESPI_FC_CAP_SHARE_MAF2_ONLY \
@@ -182,8 +191,8 @@
 	(3u << (MCHP_ESPI_FC_CAP_SHARE_POS))
 #define MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS		5u
 #define MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK0	0x07u
-#define MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK \
-	((MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK0) << (MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS))
+#define MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK ((MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK0) \
+					 << (MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS))
 #define MCHP_ESPI_FC_CAP_MAX_RD_SZ_64 \
 	((0x01u) << (MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS))
 
@@ -204,7 +213,8 @@
 #define MCHP_ESPI_RST_ISTS_POS		0u
 #define MCHP_ESPI_RST_ISTS		(1u << (MCHP_ESPI_RST_ISTS_POS))
 #define MCHP_ESPI_RST_ISTS_PIN_RO_POS	1ul
-#define MCHP_ESPI_RST_ISTS_PIN_RO_HI	(1u << (MCHP_ESPI_RST_ISTS_PIN_RO_POS))
+#define MCHP_ESPI_RST_ISTS_PIN_RO_HI \
+	(1u << (MCHP_ESPI_RST_ISTS_PIN_RO_POS))
 
 /* ESPI_RESET# Interrupt Enable */
 #define MCHP_ESPI_RST_IEN_MASK		0x01ul
@@ -219,6 +229,25 @@
 /* VW Ready */
 #define MCHP_ESPI_VW_READY_MASK		0x01ul
 #define MCHP_ESPI_VW_READY		0x01ul
+
+/* SAF Erase Block size */
+#define MCHP_ESPI_SERASE_SZ_1K_BITPOS	0
+#define MCHP_ESPI_SERASE_SZ_2K_BITPOS	1
+#define MCHP_ESPI_SERASE_SZ_4K_BITPOS	2
+#define MCHP_ESPI_SERASE_SZ_8K_BITPOS	3
+#define MCHP_ESPI_SERASE_SZ_16K_BITPOS	4
+#define MCHP_ESPI_SERASE_SZ_32K_BITPOS	5
+#define MCHP_ESPI_SERASE_SZ_64K_BITPOS	6
+#define MCHP_ESPI_SERASE_SZ_128K_BITPOS	7
+#define MCHP_ESPI_SERASE_SZ_1K		BIT(0)
+#define MCHP_ESPI_SERASE_SZ_2K		BIT(1)
+#define MCHP_ESPI_SERASE_SZ_4K		BIT(2)
+#define MCHP_ESPI_SERASE_SZ_8K		BIT(3)
+#define MCHP_ESPI_SERASE_SZ_16K		BIT(4)
+#define MCHP_ESPI_SERASE_SZ_32K		BIT(5)
+#define MCHP_ESPI_SERASE_SZ_64K		BIT(6)
+#define MCHP_ESPI_SERASE_SZ_128K	BIT(7)
+#define MCHP_ESPI_SERASE_SZ(bitpos) (1ul << ((bitpos)+10))
 
 /* VW Error Status */
 #define MCHP_ESPI_VW_ERR_STS_MASK		0x33ul
@@ -239,38 +268,51 @@
 #define MCHP_ESPI_VW_EN_STS_MASK	0x01ul
 #define MCHP_ESPI_VW_EN_STS_RO		0x01ul
 
-/* =========================================================================*/
-/* ================	      eSPI IO Component		   ================ */
-/* =========================================================================*/
-
 /**
   * @brief ESPI Host interface IO Component (MCHP_ESPI_IO)
   */
 
 /*
  * ESPI_IO_CAP - eSPI IO capabilities, channel ready, activate,
- * EC
  * registers @ 0x400F36B0
+ * VW_EN_STS (@ 0x36B0) Virtual Wire Enable Status
+ * CAP_ID (@ 0x36E0) Capabilities ID
+ * GLB_CAP0 (@ 0x36E1) Global Capabilities 0
+ * GLB_CAP1 (@ 0x36E2) Global Capabilities 1
+ * PC_CAP (@ 0x36E3) Periph Chan Capabilities
+ * VW_CAP (@ 0x36E4) Virtual Wire Chan Capabilities
+ * OOB_CAP (@ 0x36E5) OOB Chan Capabilities
+ * FC_CAP (@ 0x36E6) Flash Chan Capabilities
+ * PC_RDY (@ 0x36E7) PC ready
+ * OOB_RDY (@ 0x36E8) OOB ready
+ * FC_RDY (@ 0x36E9) OOB ready
+ * ERST_STS (@ 0x36EA) eSPI Reset interrupt status
+ * ERST_IEN (@ 0x36EB) eSPI Reset interrupt enable
+ * PLTRST_SRC (@ 0x36EC) Platform Reset Source
+ * VW_RDY (@ 0x36ED) VW ready
+ * FC_SERBZ (@ 0x36EE) S-Erase Block Size
+ * VW_ERR_STS (@ 0x37F0) IO Virtual Wire Error
  */
 typedef struct espi_io_cap_regs {
-	__IOM uint32_t VW_EN_STS;	/*! (@ 0x36B0) Virtual Wire Enable Status */
+	__IOM uint32_t VW_EN_STS;
 	uint8_t RSVD1[0x36E0 - 0x36B4];
-	__IOM uint8_t CAP_ID;	/*! (@ 0x36E0) Capabilities ID */
-	__IOM uint8_t GLB_CAP0;	/*! (@ 0x36E1) Global Capabilities 0 */
-	__IOM uint8_t GLB_CAP1;	/*! (@ 0x36E2) Global Capabilities 1 */
-	__IOM uint8_t PC_CAP;	/*! (@ 0x3633) Periph Chan Capabilities */
-	__IOM uint8_t VW_CAP;	/*! (@ 0x3634) Virtual Wire Chan Capabilities */
-	__IOM uint8_t OOB_CAP;	/*! (@ 0x3635) OOB Chan Capabilities */
-	__IOM uint8_t FC_CAP;	/*! (@ 0x3636) Flash Chan Capabilities */
-	__IOM uint8_t PC_RDY;	/*! (@ 0x3637) PC ready */
-	__IOM uint8_t OOB_RDY;	/*! (@ 0x3638) OOB ready */
-	__IOM uint8_t FC_RDY;	/*! (@ 0x3639) OOB ready */
-	__IOM uint8_t ERST_STS;	/*! (@ 0x363A) eSPI Reset interrupt status */
-	__IOM uint8_t ERST_IEN;	/*! (@ 0x363B) eSPI Reset interrupt enable */
-	__IOM uint8_t PLTRST_SRC;	/*! (@ 0x363C) Platform Reset Source */
-	__IOM uint8_t VW_RDY;	/*! (@ 0x363D) VW ready */
+	__IOM uint8_t CAP_ID;
+	__IOM uint8_t GLB_CAP0;
+	__IOM uint8_t GLB_CAP1;
+	__IOM uint8_t PC_CAP;
+	__IOM uint8_t VW_CAP;
+	__IOM uint8_t OOB_CAP;
+	__IOM uint8_t FC_CAP;
+	__IOM uint8_t PC_RDY;
+	__IOM uint8_t OOB_RDY;
+	__IOM uint8_t FC_RDY;
+	__IOM uint8_t ERST_STS;
+	__IOM uint8_t ERST_IEN;
+	__IOM uint8_t PLTRST_SRC;
+	__IOM uint8_t VW_RDY;
+	__IOM uint8_t FC_SERBZ;
 	uint8_t RSVD2[0x37F0u - 0x36EE];
-	__IOM uint32_t VW_ERR_STS;	/*! (@ 0x37F0) IO Virtual Wire Error */
+	__IOM uint32_t VW_ERR_STS;
 } ESPI_IO_CAP_Type;
 
 /*
@@ -308,6 +350,13 @@ typedef struct espi_io_cap_regs {
 /*
  * Peripheral Channel Interrupt Enables for
  * Bus error, Channel enable change, and Bus master enable change.
+ * PC_LC_ADDR_LSW (@ 0x0000) Periph Chan Last Cycle address LSW
+ * PC_LC_ADDR_MSW (@ 0x0004) Periph Chan Last Cycle address MSW
+ * PC_LC_LEN_TYPE_TAG (@ 0x0008) Periph Chan Last Cycle length/type/tag
+ * PC_ERR_ADDR_LSW (@ 0x000C) Periph Chan Error Address LSW
+ * PC_ERR_ADDR_MSW (@ 0x0010) Periph Chan Error Address MSW
+ * PC_STATUS (@ 0x0014) Periph Chan Status
+ * PC_IEN (@ 0x0018) Periph Chan IEN
  */
 #define MCHP_ESPI_PC_IEN_BUS_ERR_POS	16u
 #define MCHP_ESPI_PC_IEN_BUS_ERR	(1ul << 16)
@@ -318,18 +367,16 @@ typedef struct espi_io_cap_regs {
 
 typedef struct espi_io_pc_regs
 {
-	__IOM uint32_t PC_LC_ADDR_LSW;	/*! (@ 0x0000) Periph Chan Last Cycle address LSW */
-	__IOM uint32_t PC_LC_ADDR_MSW;	/*! (@ 0x0004) Periph Chan Last Cycle address MSW */
-	__IOM uint32_t PC_LC_LEN_TYPE_TAG;	/*! (@ 0x0008) Periph Chan Last Cycle length/type/tag */
-	__IOM uint32_t PC_ERR_ADDR_LSW;	/*! (@ 0x000C) Periph Chan Error Address LSW */
-	__IOM uint32_t PC_ERR_ADDR_MSW;	/*! (@ 0x0010) Periph Chan Error Address MSW */
-	__IOM uint32_t PC_STATUS;	/*! (@ 0x0014) Periph Chan Status */
-	__IOM uint32_t PC_IEN;	/*! (@ 0x0018) Periph Chan IEN */
+	__IOM uint32_t PC_LC_ADDR_LSW;
+	__IOM uint32_t PC_LC_ADDR_MSW;
+	__IOM uint32_t PC_LC_LEN_TYPE_TAG;
+	__IOM uint32_t PC_ERR_ADDR_LSW;
+	__IOM uint32_t PC_ERR_ADDR_MSW;
+	__IOM uint32_t PC_STATUS;
+	__IOM uint32_t PC_IEN;
 } ESPI_IO_PC_Type;
 
-/*
- * ESPI_IO_LTR - eSPI IO LTR registers @ 0x400F3620
- */
+/* ESPI_IO_LTR - eSPI IO LTR registers  */
 #define MCHP_ESPI_LTR_STS_TX_DONE_POS	0u
 #define MCHP_ESPI_LTR_STS_TX_DONE	(1ul << 0)	/* RW1C */
 #define MCHP_ESPI_LTR_STS_OVRUN_POS	3u
@@ -365,17 +412,22 @@ typedef struct espi_io_pc_regs
 /* latency computed from VAL and SC(scale) fields */
 #define MCHP_ESPI_LTR_MSG_REQ_VAL	 (1ul << 15)
 
+/*
+ * eSPI IO Component LTR registers @ 0x400F3620
+ * LTR_STS (@ 0x0000) LTR peripheral ptatus
+ * LTR_IEN (@ 0x0004) LTR peripheral interrupt enable
+ * LTR_CTRL (@ 0x0008) LTR peripheral control
+ * LTR_MSG (@ 0x000C) LTR peripheral message
+ */
 typedef struct espi_io_ltr_regs
 {
-	__IOM uint32_t LTR_STS;	/*! (@ 0x0000) LTR Periph Status */
-	__IOM uint32_t LTR_IEN;	/*! (@ 0x0004) LTR Periph Interrupt Enable */
-	__IOM uint32_t LTR_CTRL;	/*! (@ 0x0008) LTR Periph Control */
-	__IOM uint32_t LTR_MSG;	/*! (@ 0x000C) LTR Periph Message */
+	__IOM uint32_t LTR_STS;
+	__IOM uint32_t LTR_IEN;
+	__IOM uint32_t LTR_CTRL;
+	__IOM uint32_t LTR_MSG;
 } ESPI_IO_LTR_Type;
 
-/*
- * ESPI_IO_OOB - eSPI IO OOB registers @ 0x400F3640
- */
+/* ESPI_IO_OOB - eSPI IO OOB registers  */
 #define MCHP_ESPI_OOB_RX_ADDR_LSW_MASK	0xFFFFFFFCul
 #define MCHP_ESPI_OOB_TX_ADDR_LSW_MASK	0xFFFFFFFCul
 
@@ -456,25 +508,38 @@ typedef struct espi_io_ltr_regs
 
 #define MCHP_ESPI_OOB_TX_STS_ALL_RW1C	0x2Ful
 
+/*
+ * eSPI IO Component OOB registers @ 0x400F3640
+ * RX_ADDR_LSW (@ 0x0000) OOB Receive Address bits[31:0]
+ * RX_ADDR_MSW (@ 0x0004) OOB Receive Address bits[63:32]
+ * TX_ADDR_LSW (@ 0x0008) OOB Transmit Address bits[31:0]
+ * TX_ADDR_MSW (@ 0x000C) OOB Transmit Address bits[63:32]
+ * RX_LEN (@ 0x0010) OOB Receive length
+ * TX_LEN (@ 0x0014) OOB Transmit length
+ * RX_CTRL (@ 0x0018) OOB Receive control
+ * RX_IEN (@ 0x001C) OOB Receive interrupt enable
+ * RX_STS (@ 0x0020) OOB Receive interrupt status
+ * TX_CTRL (@ 0x0024) OOB Transmit control
+ * TX_IEN (@ 0x0028) OOB Transmit interrupt enable
+ * TX_STS (@ 0x002C) OOB Transmit interrupt status
+ */
 typedef struct espi_io_oob_regs
 {
-	__IOM uint32_t RX_ADDR_LSW;	/*! (@ 0x0000) OOB Receive Address bits[31:0] */
-	__IOM uint32_t RX_ADDR_MSW;	/*! (@ 0x0004) OOB Receive Address bits[63:32] */
-	__IOM uint32_t TX_ADDR_LSW;	/*! (@ 0x0008) OOB Transmit Address bits[31:0] */
-	__IOM uint32_t TX_ADDR_MSW;	/*! (@ 0x000C) OOB Transmit Address bits[63:32] */
-	__IOM uint32_t RX_LEN;	/*! (@ 0x0010) OOB Receive length */
-	__IOM uint32_t TX_LEN;	/*! (@ 0x0014) OOB Transmit length */
-	__IOM uint32_t RX_CTRL;	/*! (@ 0x0018) OOB Receive control */
-	__IOM uint32_t RX_IEN;	/*! (@ 0x001C) OOB Receive interrupt enable */
-	__IOM uint32_t RX_STS;	/*! (@ 0x0020) OOB Receive interrupt status */
-	__IOM uint32_t TX_CTRL;	/*! (@ 0x0024) OOB Transmit control */
-	__IOM uint32_t TX_IEN;	/*! (@ 0x0028) OOB Transmit interrupt enable */
-	__IOM uint32_t TX_STS;	/*! (@ 0x002C) OOB Transmit interrupt status */
+	__IOM uint32_t RX_ADDR_LSW;
+	__IOM uint32_t RX_ADDR_MSW;
+	__IOM uint32_t TX_ADDR_LSW;
+	__IOM uint32_t TX_ADDR_MSW;
+	__IOM uint32_t RX_LEN;
+	__IOM uint32_t TX_LEN;
+	__IOM uint32_t RX_CTRL;
+	__IOM uint32_t RX_IEN;
+	__IOM uint32_t RX_STS;
+	__IOM uint32_t TX_CTRL;
+	__IOM uint32_t TX_IEN;
+	__IOM uint32_t TX_STS;
 } ESPI_IO_OOB_Type;
 
-/*
- * MCHP_ESPI_IO_FC - eSPI IO Flash channel registers @ 0x40003680
- */
+/* MCHP_ESPI_IO_FC - eSPI IO Flash channel registers  */
 /* MEM_ADDR_LSW */
 #define MCHP_ESPI_FC_MEM_ADDR_LSW_MASK	0xFFFFFFFCul
 
@@ -488,13 +553,15 @@ typedef struct espi_io_oob_regs
 #define MCHP_ESPI_FC_CTRL_WR0		0x01ul
 #define MCHP_ESPI_FC_CTRL_ERS0		0x02ul
 #define MCHP_ESPI_FC_CTRL_ERL0		0x03ul
-#define MCHP_ESPI_FC_CTRL_FUNC(f) \
-	(((uint32_t)(f) & MCHP_ESPI_FC_CTRL_FUNC_MASK0) << MCHP_ESPI_FC_CTRL_FUNC_POS)
+#define MCHP_ESPI_FC_CTRL_FUNC(f) (((uint32_t)(f) & \
+				    MCHP_ESPI_FC_CTRL_FUNC_MASK0) \
+				    << MCHP_ESPI_FC_CTRL_FUNC_POS)
 #define MCHP_ESPI_FC_CTRL_TAG_POS	4u
 #define MCHP_ESPI_FC_CTRL_TAG_MASK0	0x0Ful
 #define MCHP_ESPI_FC_CTRL_TAG_MASK	(0x0Ful << 4)
-#define MCHP_ESPI_FC_CTRL_TAG(t) \
-	(((uint32_t)(t) & MCHP_ESPI_FC_CTRL_TAG_MASK0) << MCHP_ESPI_FC_CTRL_TAG_POS)
+#define MCHP_ESPI_FC_CTRL_TAG(t) (((uint32_t)(t) & \
+				   MCHP_ESPI_FC_CTRL_TAG_MASK0) \
+				   << MCHP_ESPI_FC_CTRL_TAG_POS)
 #define MCHP_ESPI_FC_CTRL_ABORT_POS	16u
 #define MCHP_ESPI_FC_CTRL_ABORT		(1ul << 16)	/* WO */
 
@@ -569,21 +636,31 @@ typedef struct espi_io_oob_regs
 
 #define MCHP_ESPI_FC_STS_ALL_RW1C	0x0BFEul
 
+/*
+ * eSPI IO Flash Channel registers @ 0x40003680
+ * FL_ADDR_LSW	(@ 0x0000) FC flash address bits[31:0]
+ * FL_ADDR_MSW (@ 0x0004) FC flash address bits[63:32]
+ * MEM_ADDR_LSW (@ 0x0008) FC EC Memory address bits[31:0]
+ * MEM_ADDR_MSW (@ 0x000C) FC EC Memory address bits[63:32]
+ * XFR_LEN (@ 0x0010) FC transfer length
+ * CTRL (@ 0x0014) FC Control
+ * IEN (@ 0x0018) FC interrupt enable
+ * CFG (@ 0x001C) FC configuration
+ * STS (@ 0x0020) FC status
+ */
 typedef struct espi_io_fc_regs {
-	__IOM uint32_t FL_ADDR_LSW;	/*! (@ 0x0000) FC flash address bits[31:0] */
-	__IOM uint32_t FL_ADDR_MSW;	/*! (@ 0x0004) FC flash address bits[63:32] */
-	__IOM uint32_t MEM_ADDR_LSW;	/*! (@ 0x0008) FC EC Memory address bits[31:0] */
-	__IOM uint32_t MEM_ADDR_MSW;	/*! (@ 0x000C) FC EC Memory address bits[63:32] */
-	__IOM uint32_t XFR_LEN;	/*! (@ 0x0010) FC transfer length */
-	__IOM uint32_t CTRL;	/*! (@ 0x0014) FC Control */
-	__IOM uint32_t IEN;	/*! (@ 0x0018) FC interrupt enable */
-	__IOM uint32_t CFG;	/*! (@ 0x001C) FC configuration */
-	__IOM uint32_t STS;	/*! (@ 0x0020) FC status */
+	__IOM uint32_t FL_ADDR_LSW;
+	__IOM uint32_t FL_ADDR_MSW;
+	__IOM uint32_t MEM_ADDR_LSW;
+	__IOM uint32_t MEM_ADDR_MSW;
+	__IOM uint32_t XFR_LEN;
+	__IOM uint32_t CTRL;
+	__IOM uint32_t IEN;
+	__IOM uint32_t CFG;
+	__IOM uint32_t STS;
 } ESPI_IO_FC_Type;
 
-/*
- * MCHP_ESPI_IO_BAR_HOST - eSPI IO Host visible BAR registers @ 0x400F3520
- */
+/* MCHP_ESPI_IO_BAR_HOST - eSPI IO Host visible BAR registers */
 
 /*
  * IOBAR_INH_LSW/MSW 64-bit register: each bit = 1 inhibits an I/O BAR
@@ -632,36 +709,64 @@ typedef struct espi_io_fc_regs {
 #define MCHP_ESPI_IO_BAR_HOST_ADDR_MASK0	0xFFFFul
 #define MCHP_ESPI_IO_BAR_HOST_ADDR_MASK		(0xFFFFul << 16)
 
+/*
+ * eSPI IO BAR Host registers.
+ * These registers contain the Host side IO address for each peripheral.
+ * IOBAR_INH_LSW (@ 0x0000) BAR Inhibit LSW
+ * IOBAR_INH_MSW (@ 0x0004) BAR Inhibit MSW
+ * IOBAR_INIT (@ 0x0008) BAR Init
+ * EC_IRQ (@ 0x000C) EC IRQ
+ * HOST_BAR_IOC (@ 0x0014) Host IO Component BAR
+ * HOST_BAR_MEM (@ 0x0018) Host IO Compoent Mem BAR
+ * HOST_BAR_MBOX (@ 0x001C) Host IO Mailbox BAR
+ * HOST_BAR_KBC (@ 0x0020) Host IO KBC BAR
+ * HOST_BAR_ACPI_EC_0 (@ 0x0024) Host IO ACPI_EC 0 BAR
+ * HOST_BAR_ACPI_EC_1 (@ 0x0028) Host IO ACPI_EC 1 BAR
+ * HOST_BAR_ACPI_EC_2 (@ 0x002C) Host IO ACPI_EC 2 BAR
+ * HOST_BAR_ACPI_EC_3 (@ 0x0030) Host IO ACPI_EC 3 BAR
+ * HOST_BAR_ACPI_PM1 (@ 0x0038) Host IO ACPI_PM1 BAR
+ * HOST_BAR_PORT92 (@ 0x003C) Host IO PORT92 BAR
+ * HOST_BAR_UART_0 (@ 0x0040) Host IO UART 0 BAR
+ * HOST_BAR_UART_1 (@ 0x0044) Host IO UART 1 BAR
+ * HOST_BAR_EMI_0 (@ 0x0048) Host IO EMI 0 BAR
+ * HOST_BAR_EMI_1 (@ 0x004C) Host IO EMI 1 BAR
+ * HOST_BAR_P80CAP_0 (@ 0x0054) Host IO Port80 Capture 0 BAR
+ * HOST_BAR_P80CAP_1 (@ 0x0058) Host IO Port80 Capture 1 BAR
+ * HOST_BAR_RTC (@ 0x005C) Host IO RTC BAR
+ * HOST_BAR_T32B (@ 0x0064) Host IO Test 32 byte BAR
+ * HOST_BAR_UART_2 (@ 0x0068) Host IO UART 2 BAR
+ * HOST_BAR_GLUE_LOG (@ 0x006C) Host IO Glue Logic BAR
+ */
 typedef struct espi_io_bar_host_regs
 {
-	__IOM uint32_t IOBAR_INH_LSW;	/*! (@ 0x0000) BAR Inhibit LSW */
-	__IOM uint32_t IOBAR_INH_MSW;	/*! (@ 0x0004) BAR Inhibit MSW */
-	__IOM uint32_t IOBAR_INIT;	/*! (@ 0x0008) BAR Init */
-	__IOM uint32_t EC_IRQ;	/*! (@ 0x000C) EC IRQ */
+	__IOM uint32_t IOBAR_INH_LSW;
+	__IOM uint32_t IOBAR_INH_MSW;
+	__IOM uint32_t IOBAR_INIT;
+	__IOM uint32_t EC_IRQ;
 	uint8_t RSVD1[4];
-	__IOM uint32_t HOST_BAR_IOC;	/*! (@ 0x0014) Host IO Component BAR */
-	__IOM uint32_t HOST_BAR_MEM;	/*! (@ 0x0018) Host IO Compoent Mem BAR */
-	__IOM uint32_t HOST_BAR_MBOX;	/*! (@ 0x001C) Host IO Mailbox BAR */
-	__IOM uint32_t HOST_BAR_KBC;	/*! (@ 0x0020) Host IO KBC BAR */
-	__IOM uint32_t HOST_BAR_ACPI_EC_0;	/*! (@ 0x0024) Host IO ACPI_EC 0 BAR */
-	__IOM uint32_t HOST_BAR_ACPI_EC_1;	/*! (@ 0x0028) Host IO ACPI_EC 1 BAR */
-	__IOM uint32_t HOST_BAR_ACPI_EC_2;	/*! (@ 0x002C) Host IO ACPI_EC 2 BAR */
-	__IOM uint32_t HOST_BAR_ACPI_EC_3;	/*! (@ 0x0030) Host IO ACPI_EC 3 BAR */
+	__IOM uint32_t HOST_BAR_IOC;
+	__IOM uint32_t HOST_BAR_MEM;
+	__IOM uint32_t HOST_BAR_MBOX;
+	__IOM uint32_t HOST_BAR_KBC;
+	__IOM uint32_t HOST_BAR_ACPI_EC_0;
+	__IOM uint32_t HOST_BAR_ACPI_EC_1;
+	__IOM uint32_t HOST_BAR_ACPI_EC_2;
+	__IOM uint32_t HOST_BAR_ACPI_EC_3;
 	uint8_t RSVD2[4];
-	__IOM uint32_t HOST_BAR_ACPI_PM1;	/*! (@ 0x0038) Host IO ACPI_PM1 BAR */
-	__IOM uint32_t HOST_BAR_PORT92;	/*! (@ 0x003C) Host IO PORT92 BAR */
-	__IOM uint32_t HOST_BAR_UART_0;	/*! (@ 0x0040) Host IO UART 0 BAR */
-	__IOM uint32_t HOST_BAR_UART_1;	/*! (@ 0x0044) Host IO UART 1 BAR */
-	__IOM uint32_t HOST_BAR_EMI_0;	/*! (@ 0x0048) Host IO EMI 0 BAR */
-	__IOM uint32_t HOST_BAR_EMI_1;	/*! (@ 0x004C) Host IO EMI 1 BAR */
+	__IOM uint32_t HOST_BAR_ACPI_PM1;
+	__IOM uint32_t HOST_BAR_PORT92;
+	__IOM uint32_t HOST_BAR_UART_0;
+	__IOM uint32_t HOST_BAR_UART_1;
+	__IOM uint32_t HOST_BAR_EMI_0;
+	__IOM uint32_t HOST_BAR_EMI_1;
 	uint8_t RSVD3[4];
-	__IOM uint32_t HOST_BAR_P80CAP_0;	/*! (@ 0x0054) Host IO Port80 Capture 0 BAR */
-	__IOM uint32_t HOST_BAR_P80CAP_1;	/*! (@ 0x0058) Host IO Port80 Capture 1 BAR */
-	__IOM uint32_t HOST_BAR_RTC;	/*! (@ 0x005C) Host IO RTC BAR */
+	__IOM uint32_t HOST_BAR_P80CAP_0;
+	__IOM uint32_t HOST_BAR_P80CAP_1;
+	__IOM uint32_t HOST_BAR_RTC;
 	uint8_t RSVD4[4];
-	__IOM uint32_t HOST_BAR_T32B;	/*! (@ 0x0064) Host IO Test 32 byte BAR */
-	__IOM uint32_t HOST_BAR_UART_2;	/*! (@ 0x0068) Host IO UART 2 BAR */
-	__IOM uint32_t HOST_BAR_GLUE_LOG;	/*! (@ 0x006C) Host IO Glue Logic BAR */
+	__IOM uint32_t HOST_BAR_T32B;
+	__IOM uint32_t HOST_BAR_UART_2;
+	__IOM uint32_t HOST_BAR_GLUE_LOG;
 } ESPI_IO_BAR_HOST_Type;
 
 /*
@@ -669,34 +774,54 @@ typedef struct espi_io_bar_host_regs
  * All fields are Read-Only
  * Address mask in bits[7:0]
  * Logical device number in bits[13:8]
+ * IO_ACTV (@ 0x0000) ESPI IO Component Activate
+ * EC_BAR_IOC (@ 0x0004) Host IO Component BAR
+ * EC_BAR_MEM (@ 0x0008) Host IO Compoent Mem BAR
+ * EC_BAR_MBOX (@ 0x000C) Host IO Mailbox BAR
+ * EC_BAR_KBC (@ 0x0010) Host IO KBC BAR
+ * EC_BAR_ACPI_EC_0 (@ 0x0014) Host IO ACPI_EC 0 BAR
+ * EC_BAR_ACPI_EC_1 (@ 0x0018) Host IO ACPI_EC 1 BAR
+ * EC_BAR_ACPI_EC_2 (@ 0x001C) Host IO ACPI_EC 2 BAR
+ * EC_BAR_ACPI_EC_3 (@ 0x0020) Host IO ACPI_EC 3 BAR
+ * EC_BAR_ACPI_PM1 (@ 0x0028) Host IO ACPI_PM1 BAR
+ * EC_BAR_PORT92 (@ 0x002C) Host IO PORT92 BAR
+ * EC_BAR_UART_0 (@ 0x0030) Host IO UART 0 BAR
+ * EC_BAR_UART_1 (@ 0x0034) Host IO UART 1 BAR
+ * EC_BAR_EMI_0 (@ 0x0038) Host IO EMI 0 BAR
+ * EC_BAR_EMI_1 (@ 0x003C) Host IO EMI 1 BAR
+ * EC_BAR_P80CAP_0 (@ 0x0044) Host IO Port80 Capture 0 BAR
+ * EC_BAR_P80CAP_1 (@ 0x0048) Host IO Port80 Capture 1 BAR
+ * EC_BAR_RTC (@ 0x004C) Host IO RTC BAR
+ * EC_BAR_T32B (@ 0x0054) Host IO Test 32 byte BAR
+ * EC_BAR_UART_2 (@ 0x0058) Host IO UART 2 BAR
+ * EC_BAR_GLUE_LOG (@ 0x005C) Host IO Glue Logic BAR
  */
-
 typedef struct espi_io_bar_ec_regs
 {
-	__IOM uint32_t IO_ACTV;	/*! (@ 0x0000) ESPI IO Component Activate */
-	__IOM uint32_t EC_BAR_IOC;	/*! (@ 0x0004) Host IO Component BAR */
-	__IOM uint32_t EC_BAR_MEM;	/*! (@ 0x0008) Host IO Compoent Mem BAR */
-	__IOM uint32_t EC_BAR_MBOX;	/*! (@ 0x000C) Host IO Mailbox BAR */
-	__IOM uint32_t EC_BAR_KBC;	/*! (@ 0x0010) Host IO KBC BAR */
-	__IOM uint32_t EC_BAR_ACPI_EC_0;	/*! (@ 0x0014) Host IO ACPI_EC 0 BAR */
-	__IOM uint32_t EC_BAR_ACPI_EC_1;	/*! (@ 0x0018) Host IO ACPI_EC 1 BAR */
-	__IOM uint32_t EC_BAR_ACPI_EC_2;	/*! (@ 0x001C) Host IO ACPI_EC 2 BAR */
-	__IOM uint32_t EC_BAR_ACPI_EC_3;	/*! (@ 0x0020) Host IO ACPI_EC 3 BAR */
+	__IOM uint32_t IO_ACTV;
+	__IOM uint32_t EC_BAR_IOC;
+	__IOM uint32_t EC_BAR_MEM;
+	__IOM uint32_t EC_BAR_MBOX;
+	__IOM uint32_t EC_BAR_KBC;
+	__IOM uint32_t EC_BAR_ACPI_EC_0;
+	__IOM uint32_t EC_BAR_ACPI_EC_1;
+	__IOM uint32_t EC_BAR_ACPI_EC_2;
+	__IOM uint32_t EC_BAR_ACPI_EC_3;
 	uint8_t RSVD2[4];
-	__IOM uint32_t EC_BAR_ACPI_PM1;	/*! (@ 0x0028) Host IO ACPI_PM1 BAR */
-	__IOM uint32_t EC_BAR_PORT92;	/*! (@ 0x002C) Host IO PORT92 BAR */
-	__IOM uint32_t EC_BAR_UART_0;	/*! (@ 0x0030) Host IO UART 0 BAR */
-	__IOM uint32_t EC_BAR_UART_1;	/*! (@ 0x0034) Host IO UART 1 BAR */
-	__IOM uint32_t EC_BAR_EMI_0;	/*! (@ 0x0038) Host IO EMI 0 BAR */
-	__IOM uint32_t EC_BAR_EMI_1;	/*! (@ 0x003C) Host IO EMI 1 BAR */
+	__IOM uint32_t EC_BAR_ACPI_PM1;
+	__IOM uint32_t EC_BAR_PORT92;
+	__IOM uint32_t EC_BAR_UART_0;
+	__IOM uint32_t EC_BAR_UART_1;
+	__IOM uint32_t EC_BAR_EMI_0;
+	__IOM uint32_t EC_BAR_EMI_1;
 	uint8_t RSVD3[4];
-	__IOM uint32_t EC_BAR_P80CAP_0;	/*! (@ 0x0044) Host IO Port80 Capture 0 BAR */
-	__IOM uint32_t EC_BAR_P80CAP_1;	/*! (@ 0x0048) Host IO Port80 Capture 1 BAR */
-	__IOM uint32_t EC_BAR_RTC;	/*! (@ 0x004C) Host IO RTC BAR */
+	__IOM uint32_t EC_BAR_P80CAP_0;
+	__IOM uint32_t EC_BAR_P80CAP_1;
+	__IOM uint32_t EC_BAR_RTC;
 	uint8_t RSVD4[4];
-	__IOM uint32_t EC_BAR_T32B;	/*! (@ 0x0054) Host IO Test 32 byte BAR */
-	__IOM uint32_t EC_BAR_UART_2;	/*! (@ 0x0058) Host IO UART 2 BAR */
-	__IOM uint32_t EC_BAR_GLUE_LOG;	/*! (@ 0x005C) Host IO Glue Logic BAR */
+	__IOM uint32_t EC_BAR_T32B;
+	__IOM uint32_t EC_BAR_UART_2;
+	__IOM uint32_t EC_BAR_GLUE_LOG;
 } ESPI_IO_BAR_EC_Type;
 
 /* Offsets from first SIRQ */
@@ -723,8 +848,24 @@ typedef struct espi_io_bar_ec_regs
 #define MCHP_ESPI_SIRQ_MAX		20ul
 
 /*
- * MCHP_ESPI_IO_SIRQ - eSPI IO Component Logical Device Serial IRQ configuration
- * @ 0x400F37A0
+ * eSPI IO Component Logical Device Serial IRQ configuration @ 0x400F37A0
+ * MBOX_SIRQ_0 (@ 0x000C) Mailbox SIRQ 0 config
+ * MBOX_SIRQ_1 (@ 0x000D) Mailbox SIRQ 1 config
+ * KBC_SIRQ_0 (@ 0x000E) KBC SIRQ 0 config
+ * KBC_SIRQ_1 (@ 0x000F) KBC SIRQ 1 config
+ * ACPI_EC_0_SIRQ (@ 0x0010) ACPI EC 0 SIRQ config
+ * ACPI_EC_1_SIRQ (@ 0x0011) ACPI EC 1 SIRQ config
+ * ACPI_EC_2_SIRQ (@ 0x0012) ACPI EC 2 SIRQ config
+ * ACPI_EC_3_SIRQ (@ 0x0013) ACPI EC 3 SIRQ config
+ * UART_0_SIRQ (@ 0x0015) UART 0 SIRQ config
+ * UART_1_SIRQ (@ 0x0016) UART 1 SIRQ config
+ * EMI_0_SIRQ_0 (@ 0x0017) EMI 0 SIRQ 0 config
+ * EMI_0_SIRQ_1 (@ 0x0018) EMI 0 SIRQ 1 config
+ * EMI_1_SIRQ_0 (@ 0x0019) EMI 1 SIRQ 0 config
+ * EMI_1_SIRQ_1 (@ 0x001A) EMI 1 SIRQ 1 config
+ * RTC_SIRQ (@ 0x001D) RTC SIRQ config
+ * EC_SIRQ (@ 0x001E) EC SIRQ config
+ * UART_2_SIRQ (@ 0x001F) UART 2 SIRQ config
  */
 /*
  * Values for Logical Device SIRQ registers.
@@ -739,25 +880,25 @@ typedef struct espi_io_bar_ec_regs
 typedef struct espi_io_sirq_regs
 {
 	uint8_t RSVD1[12];
-	__IOM uint8_t MBOX_SIRQ_0;	/*! (@ 0x000C) Mailbox SIRQ 0 config */
-	__IOM uint8_t MBOX_SIRQ_1;	/*! (@ 0x000D) Mailbox SIRQ 1 config */
-	__IOM uint8_t KBC_SIRQ_0;	/*! (@ 0x000E) KBC SIRQ 0 config */
-	__IOM uint8_t KBC_SIRQ_1;	/*! (@ 0x000F) KBC SIRQ 1 config */
-	__IOM uint8_t ACPI_EC_0_SIRQ;	/*! (@ 0x0010) ACPI EC 0 SIRQ config */
-	__IOM uint8_t ACPI_EC_1_SIRQ;	/*! (@ 0x0011) ACPI EC 1 SIRQ config */
-	__IOM uint8_t ACPI_EC_2_SIRQ;	/*! (@ 0x0012) ACPI EC 2 SIRQ config */
-	__IOM uint8_t ACPI_EC_3_SIRQ;	/*! (@ 0x0013) ACPI EC 3 SIRQ config */
+	__IOM uint8_t MBOX_SIRQ_0;
+	__IOM uint8_t MBOX_SIRQ_1;
+	__IOM uint8_t KBC_SIRQ_0;
+	__IOM uint8_t KBC_SIRQ_1;
+	__IOM uint8_t ACPI_EC_0_SIRQ;
+	__IOM uint8_t ACPI_EC_1_SIRQ;
+	__IOM uint8_t ACPI_EC_2_SIRQ;
+	__IOM uint8_t ACPI_EC_3_SIRQ;
 	uint8_t RSVD2[1];
-	__IOM uint8_t UART_0_SIRQ;	/*! (@ 0x0015) UART 0 SIRQ config */
-	__IOM uint8_t UART_1_SIRQ;	/*! (@ 0x0016) UART 1 SIRQ config */
-	__IOM uint8_t EMI_0_SIRQ_0;	/*! (@ 0x0017) EMI 0 SIRQ 0 config */
-	__IOM uint8_t EMI_0_SIRQ_1;	/*! (@ 0x0018) EMI 0 SIRQ 1 config */
-	__IOM uint8_t EMI_1_SIRQ_0;	/*! (@ 0x0019) EMI 1 SIRQ 0 config */
-	__IOM uint8_t EMI_1_SIRQ_1;	/*! (@ 0x001A) EMI 1 SIRQ 1 config */
+	__IOM uint8_t UART_0_SIRQ;
+	__IOM uint8_t UART_1_SIRQ;
+	__IOM uint8_t EMI_0_SIRQ_0;
+	__IOM uint8_t EMI_0_SIRQ_1;
+	__IOM uint8_t EMI_1_SIRQ_0;
+	__IOM uint8_t EMI_1_SIRQ_1;
 	uint8_t RSVD3[2];
-	__IOM uint8_t RTC_SIRQ;	/*! (@ 0x001D) RTC SIRQ config */
-	__IOM uint8_t EC_SIRQ;	/*! (@ 0x001E) EC SIRQ config */
-	__IOM uint8_t UART_2_SIRQ;	/*! (@ 0x001F) UART 2 SIRQ config */
+	__IOM uint8_t RTC_SIRQ;
+	__IOM uint8_t EC_SIRQ;
+	__IOM uint8_t UART_2_SIRQ;
 } ESPI_IO_SIRQ_Type;
 
 #endif				/* #ifndef _ESPI_IO_H */

--- a/mec/mec1501/component/espi_saf.h
+++ b/mec/mec1501/component/espi_saf.h
@@ -1,0 +1,553 @@
+/*
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Header with definitions for MCHP eSPI SAF registers
+ */
+
+#ifndef ESPI_SAF_H_
+#define ESPI_SAF_H_
+
+#include <stdint.h>
+
+#define MCHP_ESPI_SAF_BASE_ADDR 0x40008000
+#define MCHP_ESPI_SAF_COMM_BASE_ADDR 0x40071000
+
+#define MCHP_ESPI_SAF_CS_MAX 2
+
+/* Three TAG Map registers */
+#define MCHP_ESPI_SAF_TAGMAP_MAX 3
+/* 17 protection regions */
+#define MCHP_ESPI_SAF_PR_MAX 17
+
+/*
+ * SAF SPI Opcoded and indices specifying start QMSPI descriptor for
+ * each opcode. There is one register group per flash device.
+ * OPA: read status1, resume, suspend, write enable
+ * OPB: erase 4KB, erase 32KB, erase 64KB, page program
+ * OPC: Fast Read Quad or Dual, N/A, continuous mode byte, read status 2
+ * OP_DESCR: contains QMSPI descriptor indices for various opcode fields.
+ */
+struct mchp_espi_saf_op {
+	volatile uint32_t OPA;
+	volatile uint32_t OPB;
+	volatile uint32_t OPC;
+	volatile uint32_t OP_DESCR;
+};
+
+/*
+ * SAF protection regions contain 4 32-bit registers:
+ * Start address in 4KB units.
+ * Limit address in 4KB units.
+ * Write-erase eSPI Master bit-map.
+ * Read access eSPI Master bit-map.
+ */
+struct mchp_espi_saf_pr {
+	volatile uint32_t START;
+	volatile uint32_t LIMIT;
+	volatile uint32_t WEBM;
+	volatile uint32_t RDBM;
+};
+
+/*
+ * SAF configuration and control registers
+ */
+struct mchp_espi_saf {
+		 uint32_t RSVD1[6];
+	volatile uint32_t SAF_ECP_CMD;
+	volatile uint32_t SAF_ECP_FLAR;
+	volatile uint32_t SAF_ECP_START;
+	volatile uint32_t SAF_ECP_BFAR;
+	volatile uint32_t SAF_ECP_STATUS;
+	volatile uint32_t SAF_ECP_INTEN;
+	volatile uint32_t SAF_FL_CFG_SIZE_LIM;
+	volatile uint32_t SAF_FL_CFG_THRH;
+	volatile uint32_t SAF_FL_CFG_MISC;
+	volatile uint32_t SAF_ESPI_MON_STATUS;
+	volatile uint32_t SAF_ESPI_MON_INTEN;
+	volatile uint32_t SAF_ECP_BUSY;
+		 uint32_t RSVD2[1];
+	struct mchp_espi_saf_op SAF_CS_OP[MCHP_ESPI_SAF_CS_MAX];
+	volatile uint32_t SAF_FL_CFG_GEN_DESCR;
+	volatile uint32_t SAF_PROT_LOCK;
+	volatile uint32_t SAF_PROT_DIRTY;
+	volatile uint32_t SAF_TAG_MAP[MCHP_ESPI_SAF_TAGMAP_MAX];
+	struct mchp_espi_saf_pr SAF_PROT_RG[MCHP_ESPI_SAF_PR_MAX];
+	volatile uint32_t SAF_POLL_TMOUT;
+	volatile uint32_t SAF_POLL_INTRVL;
+	volatile uint32_t SAF_SUS_RSM_INTRVL;
+	volatile uint32_t SAF_CONSEC_RD_TMOUT;
+	volatile uint16_t SAF_CS0_CFG_P2M;
+	volatile uint16_t SAF_CS1_CFG_P2M;
+	volatile uint32_t SAF_FL_CFG_SPM;
+	volatile uint32_t SAF_SUS_CHK_DLY;
+	volatile uint16_t SAF_CS0_CM_PRF;
+	volatile uint16_t SAF_CS1_CM_PRF;
+	volatile uint32_t SAF_DNX_PROT_BYP;
+};
+typedef struct mchp_espi_saf MCHP_SAF_HW_REGS;
+
+#define MCHP_SAF_FL_CM_PRF_CS0_OFS	0x1b0
+#define MCHP_SAF_FL_CM_PRF_CS1_OFS	0x1b2
+
+
+#define MCHP_ESPI_SAF_BASE	0x40008000
+#define MCHP_ESPI_SAF_COMM_BASE	0x40071000
+#define MCHP_ESPI_SAF_COMM_MODE_OFS	0x2b8
+#define MCHP_ESPI_SAF_COMM_MODE_ADDR	(MCHP_ESPI_SAF_COMM_BASE_ADDR + \
+					 MCHP_ESPI_SAF_COMM_MODE_OFS)
+
+/* SAF Protection region described by 4 32-bit registers. 17 regions */
+#define MCHP_ESPI_SAF_PROT_MAX 17
+
+/* SAF register structure pointer */
+#define MCHP_SAF_REGS ((MCHP_SAF_HW_REGS *)(MCHP_ESPI_SAF_BASE_ADDR))
+
+/* SAF Communication Mode register */
+#define MCHP_SAF_COMM_MODE_REG \
+	*(volatile uint32_t *)(MCHP_ESPI_SAF_COMM_MODE_ADDR)
+
+/*
+ * Interrupt connections
+ * HW bug: SAF interrupts do not have direct NVIC connections.
+ */
+#define MCHP_SAF_GIRQ 18
+#define MCHP_SAF_GIRQ_ECP_DONE_POS 9
+#define MCHP_SAF_GIRQ_ERROR_POS 10
+#define MCHP_SAF_GIRQ_ECP_DONE_BIT BIT(9)
+#define MCHP_SAF_GIRQ_ERROR_BIT BIT(10)
+
+
+/* Register bit definitions */
+
+/* SAF EC Portal Command register */
+#define MCHP_SAF_ECP_CMD_OFS		0x18
+#define MCHP_SAF_ECP_CMD_MASK		0xff00ffff
+#define MCHP_SAF_ECP_CMD_PUT_POS	0
+#define MCHP_SAF_ECP_CMD_PUT_MASK	0xff
+#define MCHP_SAF_ECP_CMD_PUT_FLASH_NP	0x0a
+#define MCHP_SAF_ECP_CMD_CTYPE_POS	8
+#define MCHP_SAF_ECP_CMD_CTYPE_READ0	0x00
+#define MCHP_SAF_ECP_CMD_CTYPE_WRITE0	0x01
+#define MCHP_SAF_ECP_CMD_CTYPE_ERASE0	0x02
+#define MCHP_SAF_ECP_CMD_CTYPE_MAX0	0x03
+#define MCHP_SAF_ECP_CMD_CTYPE_MASK	(0xff << MCHP_SAF_ECP_CMD_CTYPE_POS)
+#define MCHP_SAF_ECP_CMD_CTYPE_READ	(0x00 << MCHP_SAF_ECP_CMD_CTYPE_POS)
+#define MCHP_SAF_ECP_CMD_CTYPE_WRITE	(0x01 << MCHP_SAF_ECP_CMD_CTYPE_POS)
+#define MCHP_SAF_ECP_CMD_CTYPE_ERASE	(0x02 << MCHP_SAF_ECP_CMD_CTYPE_POS)
+#define MCHP_SAF_ECP_CMD_LEN_POS	24
+#define MCHP_SAF_ECP_CMD_LEN_MASK0	0xff
+#define MCHP_SAF_ECP_CMD_LEN_MASK	(0xff << MCHP_SAF_ECP_CMD_LEN_POS)
+/* Read/Write request size (1 <= reqlen <= 64) bytes */
+#define MCHP_SAF_ECP_CMD_RW_LEN_MIN	1
+#define MCHP_SAF_ECP_CMD_RW_LEN_MAX	64
+/* Only three erase sizes are supported encoded as */
+#define MCHP_SAF_ECP_CMD_ERASE_4K (0x00 << MCHP_SAF_ECP_CMD_LEN_POS)
+#define MCHP_SAF_ECP_CMD_ERASE_32K (0x01 << MCHP_SAF_ECP_CMD_LEN_POS)
+#define MCHP_SAF_ECP_CMD_ERASE_64K (0x02 << MCHP_SAF_ECP_CMD_LEN_POS)
+
+/* SAF EC Portal Flash Address register */
+#define MCHP_SAF_ECP_FLAR_OFS	0x1c
+#define MCHP_SAF_ECP_FLAR_MASK	0xffffffff
+
+/* SAF EC Portal Start register */
+#define MCHP_SAF_ECP_START_OFS	0x20
+#define MCHP_SAF_ECP_START_MASK	0x01
+#define MCHP_SAF_ECP_START	BIT(0)
+
+/* SAF EC Portal Buffer Address register */
+#define MCHP_SAF_ECP_BFAR_OFS	0x24
+#define MCHP_SAF_ECP_BFAR_MASK	0xfffffffc
+
+/* SAF EC Portal Status register */
+#define MCHP_SAF_ECP_STS_OFS		0x28
+#define MCHP_SAF_ECP_STS_MASK		0x1ff
+#define MCHP_SAF_ECP_STS_ERR_MASK	0x1fc
+#define MCHP_SAF_ECP_STS_DONE		BIT(0)
+#define MCHP_SAF_ECP_STS_DONE_TST	BIT(1)
+#define MCHP_SAF_ECP_STS_TMOUT		BIT(2)
+#define MCHP_SAF_ECP_STS_OOR		BIT(3)
+#define MCHP_SAF_ECP_STS_AV		BIT(4)
+#define MCHP_SAF_ECP_STS_BND_4K		BIT(5)
+#define MCHP_SAF_ECP_STS_ERSZ		BIT(6)
+#define MCHP_SAF_ECP_STS_ST_OVFL	BIT(6)
+#define MCHP_SAF_ECP_STS_BAD_REQ	BIT(8)
+
+/* SAF EC Portal Interrupt Enable register */
+#define MCHP_SAF_ECP_INTEN_OFS	0x2c
+#define MCHP_SAF_ECP_INTEN_MASK	0x01
+#define MCHP_SAF_ECP_INTEN_DONE	BIT(0)
+
+/* SAF Flash Configuratin Size Limit register */
+#define MCHP_SAF_FL_CFG_SIZE_LIM_OFS	0x30
+#define MCHP_SAF_FL_CFG_SIZE_LIM_MASK	0xffffffff
+
+/* SAF Flash Configuration Threshold register */
+#define MCHP_SAF_FL_CFG_THRH_OFS	0x34
+#define MCHP_SAF_FL_CFG_THRH_MASK	0xffffffff
+
+/* SAF Flash Configuration Miscellaneous register */
+#define MCHP_SAF_FL_CFG_MISC_OFS	0x38
+#define MCHP_SAF_FL_CFG_MISC_MASK	0x000030f3
+#define MCHP_SAF_FL_CFG_MISC_PFOE_MASK	0x03
+#define MCHP_SAF_FL_CFG_MISC_PFOE_DFLT	0x00
+#define MCHP_SAF_FL_CFG_MISC_PFOE_EXP	0x03
+#define MCHP_SAF_FL_CFG_MISC_CS0_4BM	BIT(4)
+#define MCHP_SAF_FL_CFG_MISC_CS1_4BM	BIT(5)
+#define MCHP_SAF_FL_CFG_MISC_CS0_CPE	BIT(6)
+#define MCHP_SAF_FL_CFG_MISC_CS1_CPE	BIT(7)
+#define MCHP_SAF_FL_CFG_MISC_SAF_EN	BIT(12)
+#define MCHP_SAF_FL_CFG_MISC_SAF_LOCK	BIT(13)
+
+/* SAF eSPI Monitor Status register */
+#define MCHP_SAF_ESPI_MON_STATUS_OFS	0x3c
+#define MCHP_SAF_ESPI_MON_STATUS_MASK	0x1F
+#define MCHP_SAF_ESPI_MON_STS_TMOUT	BIT(0)
+#define MCHP_SAF_ESPI_MON_STS_OOR	BIT(1)
+#define MCHP_SAF_ESPI_MON_STS_AV	BIT(2)
+#define MCHP_SAF_ESPI_MON_STS_BND_4K	BIT(3)
+#define MCHP_SAF_ESPI_MON_STS_ERSZ	BIT(4)
+
+/* SAF eSPI Monitor Interrupt Enable register */
+#define MCHP_SAF_ESPI_MON_INTEN_OFS	0x40
+#define MCHP_SAF_ESPI_MON_INTEN_MASK	0x1F
+#define MCHP_SAF_ESPI_MON_INTEN_TMOUT	BIT(0)
+#define MCHP_SAF_ESPI_MON_INTEN_OOR	BIT(1)
+#define MCHP_SAF_ESPI_MON_INTEN_AV	BIT(2)
+#define MCHP_SAF_ESPI_MON_INTEN_BND_4K	BIT(3)
+#define MCHP_SAF_ESPI_MON_INTEN_ERSZ	BIT(4)
+
+/* SAF EC Portal Busy register */
+#define MCHP_SAF_ECP_BUSY_OFS		0x44
+#define MCHP_SAF_ECP_BUSY_MASK		0x01
+#define MCHP_SAF_ECP_BUSY		BIT(0)
+
+/* SAF CS0/CS1 Opcode A registers */
+#define MCHP_SAF_CS0_OPA_OFS	0x4c
+#define MCHP_SAF_CS1_OPA_OFS	0x5c
+#define MCHP_SAF_CS_OPA_MASK	0xffffffff
+#define MCHP_SAF_CS_OPA_WE_POS	0
+#define MCHP_SAF_CS_OPA_WE_MASK	0xff
+#define MCHP_SAF_CS_OPA_SUS_POS	8
+#define MCHP_SAF_CS_OPA_SUS_MASK	(0xff << MCHP_SAF_CS_OPA_SUS_POS)
+#define MCHP_SAF_CS_OPA_RSM_POS	16
+#define MCHP_SAF_CS_OPA_RSM_MASK	(0xff << MCHP_SAF_CS_OPA_RSM_POS)
+#define MCHP_SAF_CS_OPA_POLL1_POS	24
+#define MCHP_SAF_CS_OPA_POLL1_MASK	(0xff << MCHP_SAF_CS_OPA_POLL1_POS)
+
+/* SAF CS0/CS1 Opcode B registers */
+#define MCHP_SAF_CS0_OPB_OFS	0x50
+#define MCHP_SAF_CS1_OPB_OFS	0x60
+#define MCHP_SAF_CS_OPB_OFS	0xffffffff
+#define MCHP_SAF_CS_OPB_ER0_POS	0
+#define MCHP_SAF_CS_OPB_ER0_MASK	0xff
+#define MCHP_SAF_CS_OPB_ER1_POS	8
+#define MCHP_SAF_CS_OPB_ER1_MASK	(0xff << MCHP_SAF_CS_OPB_ER1_POS)
+#define MCHP_SAF_CS_OPB_ER2_POS	16
+#define MCHP_SAF_CS_OPB_ER2_MASK	(0xff << MCHP_SAF_CS_OPB_ER2_POS)
+#define MCHP_SAF_CS_OPB_PGM_POS	24
+#define MCHP_SAF_CS_OPB_PGM_MASK	(0xff << MCHP_SAF_CS_OPB_PGM_POS)
+
+/* SAF CS0/CS1 Opcode C registers */
+#define MCHP_SAF_CS0_OPC_OFS	0x54
+#define MCHP_SAF_CS1_OPC_OFS	0x64
+#define MCHP_SAF_CS_OPC_MASK	0xffffffff
+#define MCHP_SAF_CS_OPC_RD_POS		0
+#define MCHP_SAF_CS_OPC_RD_MASK	0xff
+#define MCHP_SAF_CS_OPC_MNC_POS		8
+#define MCHP_SAF_CS_OPC_MNC_MASK	(0xff << MCHP_SAF_CS_OPC_MN_POS)
+#define MCHP_SAF_CS_OPC_MC_POS		16
+#define MCHP_SAF_CS_OPC_MC_MASK	(0xff << MCHP_SAF_CS_OPC_MC_POS)
+#define MCHP_SAF_CS_OPC_POLL2_POS	24
+#define MCHP_SAF_CS_OPC_POLL2_MASK	(0xff << MCHP_SAF_CS_OPC_POLL2_POS)
+
+/* SAF CS0/CS1 registers */
+#define MCHP_SAF_CS0_DESCR_OFS	0x58
+#define MCHP_SAF_CS1_DESCR_OFS	0x68
+#define MCHP_SAF_CS_DESCR_MASK	0x0000ff0f
+#define MCHP_SAF_CS_DESCR_ENTC_POS	0
+#define MCHP_SAF_CS_DESCR_ENTC_MASK	0x0f
+#define MCHP_SAF_CS_DESCR_RDC_POS	8
+#define MCHP_SAF_CS_DESCR_RDC_MASK	(0x0f << MCHP_SAF_CS_DESCR_RDC_POS)
+#define MCHP_SAF_CS_DESCR_SZC_POS	12
+#define MCHP_SAF_CS_DESCR_SZC_MASK	(0x0f << MCHP_SAF_CS_DESCR_SZC_POS)
+
+/* SAF Flash Configuration General Descriptors register */
+#define MCHP_SAF_FL_CFG_GEN_DESCR_OFS	0x6c
+#define MCHP_SAF_FL_CFG_GEN_DESCR_MASK	0x0000ff0f
+/* value for standard 16 descriptor programming */
+#define MCHP_SAF_FL_CFG_GEN_DESCR_STD	0x0000ee0c
+#define MCHP_SAF_FL_CFG_GEN_DESCR_EXC_POS	0
+#define MCHP_SAF_FL_CFG_GEN_DESCR_EXC_MASK	0x0f
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL1_POS	8
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL1_MASK \
+	(0x0f << MCHP_SAF_FL_CFG_GEN_DESCR_POLL1_POS)
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL2_POS	12
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL2_MASK \
+	(0x0f << MCHP_SAF_FL_CFG_GEN_DESCR_POLL2_POS)
+
+/* SAF Protection Lock register */
+#define MCHP_SAF_PROT_LOCK_OFS		0x70
+#define MCHP_SAF_PROT_LOCK_MASK	0x1ffff
+#define MCHP_SAF_PROT_LOCK0	BIT(0)
+#define MCHP_SAF_PROT_LOCK1	BIT(1)
+#define MCHP_SAF_PROT_LOCK2	BIT(2)
+#define MCHP_SAF_PROT_LOCK3	BIT(3)
+#define MCHP_SAF_PROT_LOCK4	BIT(4)
+#define MCHP_SAF_PROT_LOCK5	BIT(5)
+#define MCHP_SAF_PROT_LOCK6	BIT(6)
+#define MCHP_SAF_PROT_LOCK7	BIT(7)
+#define MCHP_SAF_PROT_LOCK8	BIT(8)
+#define MCHP_SAF_PROT_LOCK9	BIT(9)
+#define MCHP_SAF_PROT_LOCK10	BIT(10)
+#define MCHP_SAF_PROT_LOCK11	BIT(11)
+#define MCHP_SAF_PROT_LOCK12	BIT(12)
+#define MCHP_SAF_PROT_LOCK13	BIT(13)
+#define MCHP_SAF_PROT_LOCK14	BIT(14)
+#define MCHP_SAF_PROT_LOCK15	BIT(15)
+#define MCHP_SAF_PROT_LOCK16	BIT(16)
+
+/* SAF Protection Dirty register */
+#define MCHP_SAF_PROT_DIRTY_OFS	0x74
+#define MCHP_SAF_PROT_DIRTY_MASK	0x00fff
+#define MCHP_SAF_PROT_DIRTY0	BIT(0)
+#define MCHP_SAF_PROT_DIRTY1	BIT(1)
+#define MCHP_SAF_PROT_DIRTY2	BIT(2)
+#define MCHP_SAF_PROT_DIRTY3	BIT(3)
+#define MCHP_SAF_PROT_DIRTY4	BIT(4)
+#define MCHP_SAF_PROT_DIRTY5	BIT(5)
+#define MCHP_SAF_PROT_DIRTY6	BIT(6)
+#define MCHP_SAF_PROT_DIRTY7	BIT(7)
+#define MCHP_SAF_PROT_DIRTY8	BIT(8)
+#define MCHP_SAF_PROT_DIRTY9	BIT(9)
+#define MCHP_SAF_PROT_DIRTY10	BIT(10)
+#define MCHP_SAF_PROT_DIRTY11	BIT(11)
+
+/* SAF Tag Map 0 register */
+#define MCHP_SAF_TAG_MAP0_OFS		0x78
+#define MCHP_SAF_TAG_MAP0_MASK		0x77777777
+#define MCHP_SAF_TAG_MAP0_DFLT		0x23221100
+#define MCHP_SAF_TAG_MAP0_STM0_POS	0
+#define MCHP_SAF_TAG_MAP0_STM0_MASK	0x07
+#define MCHP_SAF_TAG_MAP0_STM1_POS	4
+#define MCHP_SAF_TAG_MAP0_STM1_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM1_POS)
+#define MCHP_SAF_TAG_MAP0_STM2_POS	8
+#define MCHP_SAF_TAG_MAP0_STM2_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM2_POS)
+#define MCHP_SAF_TAG_MAP0_STM3_POS	12
+#define MCHP_SAF_TAG_MAP0_STM3_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM3_POS)
+#define MCHP_SAF_TAG_MAP0_STM4_POS	16
+#define MCHP_SAF_TAG_MAP0_STM4_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM4_POS)
+#define MCHP_SAF_TAG_MAP0_STM5_POS	20
+#define MCHP_SAF_TAG_MAP0_STM5_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM5_POS)
+#define MCHP_SAF_TAG_MAP0_STM6_POS	24
+#define MCHP_SAF_TAG_MAP0_STM6_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM6_POS)
+#define MCHP_SAF_TAG_MAP0_STM7_POS	28
+#define MCHP_SAF_TAG_MAP0_STM7_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM7_POS)
+
+/* SAF Tag Map 1 register */
+#define MCHP_SAF_TAG_MAP1_OFS		0x7c
+#define MCHP_SAF_TAG_MAP1_MASK		0x77777777
+#define MCHP_SAF_TAG_MAP1_DFLT		0x77677767
+#define MCHP_SAF_TAG_MAP1_STM8_POS	0
+#define MCHP_SAF_TAG_MAP1_STM8_MASK	0x07
+#define MCHP_SAF_TAG_MAP1_STM9_POS	4
+#define MCHP_SAF_TAG_MAP1_STM9_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STM9_POS)
+#define MCHP_SAF_TAG_MAP1_STMA_POS	8
+#define MCHP_SAF_TAG_MAP1_STMA_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STMA_POS)
+#define MCHP_SAF_TAG_MAP1_STMB_POS	12
+#define MCHP_SAF_TAG_MAP1_STMB_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STMB_POS)
+#define MCHP_SAF_TAG_MAP1_STMC_POS	16
+#define MCHP_SAF_TAG_MAP1_STMC_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STMC_POS)
+#define MCHP_SAF_TAG_MAP1_STMD_POS	20
+#define MCHP_SAF_TAG_MAP1_STMD_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STMD_POS)
+#define MCHP_SAF_TAG_MAP1_STME_POS	24
+#define MCHP_SAF_TAG_MAP1_STME_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STME_POS)
+#define MCHP_SAF_TAG_MAP1_STMF_POS	28
+#define MCHP_SAF_TAG_MAP1_STMF_MASK	(0x07 << MCHP_SAF_TAG_MAP1_STMF_POS)
+
+/* SAF Tag Map 2 register */
+#define MCHP_SAF_TAG_MAP2_OFS		0x80
+#define MCHP_SAF_TAG_MAP2_MASK		0x80000007
+#define MCHP_SAF_TAG_MAP2_DFLT		0x00000005
+#define MCHP_SAF_TAG_MAP2_SM_EC_POS	0
+#define MCHP_SAF_TAG_MAP2_SM_EC_MASK	0x07
+#define MCHP_SAF_TAG_MAP2_LOCK_POS	31
+#define MCHP_SAF_TAG_MAP2_LOCK		BIT(31)
+
+/* SAF Protection Region Start registers */
+#define MCHP_SAF_PROT_RG0_START_OFS	0x84
+#define MCHP_SAF_PROT_RG1_START_OFS	0x94
+#define MCHP_SAF_PROT_RG2_START_OFS	0xa4
+#define MCHP_SAF_PROT_RG3_START_OFS	0xb4
+#define MCHP_SAF_PROT_RG4_START_OFS	0xc4
+#define MCHP_SAF_PROT_RG5_START_OFS	0xd4
+#define MCHP_SAF_PROT_RG6_START_OFS	0xe4
+#define MCHP_SAF_PROT_RG7_START_OFS	0xf4
+#define MCHP_SAF_PROT_RG8_START_OFS	0x104
+#define MCHP_SAF_PROT_RG9_START_OFS	0x114
+#define MCHP_SAF_PROT_RG10_START_OFS	0x124
+#define MCHP_SAF_PROT_RG11_START_OFS	0x134
+#define MCHP_SAF_PROT_RG12_START_OFS	0x144
+#define MCHP_SAF_PROT_RG13_START_OFS	0x154
+#define MCHP_SAF_PROT_RG14_START_OFS	0x164
+#define MCHP_SAF_PROT_RG15_START_OFS	0x174
+#define MCHP_SAF_PROT_RG16_START_OFS	0x184
+#define MCHP_SAF_PROT_RG_START_MASK	0xfffff
+#define MCHP_SAF_PROT_RG_START_DFLT	0x07fff
+
+/* SAF Protection Region Limit registers */
+#define MCHP_SAF_PROT_RG0_LIMIT_OFS	0x88
+#define MCHP_SAF_PROT_RG1_LIMIT_OFS	0x98
+#define MCHP_SAF_PROT_RG2_LIMIT_OFS	0xa8
+#define MCHP_SAF_PROT_RG3_LIMIT_OFS	0xb8
+#define MCHP_SAF_PROT_RG4_LIMIT_OFS	0xc8
+#define MCHP_SAF_PROT_RG5_LIMIT_OFS	0xd8
+#define MCHP_SAF_PROT_RG6_LIMIT_OFS	0xe8
+#define MCHP_SAF_PROT_RG7_LIMIT_OFS	0xf8
+#define MCHP_SAF_PROT_RG8_LIMIT_OFS	0x108
+#define MCHP_SAF_PROT_RG9_LIMIT_OFS	0x118
+#define MCHP_SAF_PROT_RG10_LIMIT_OFS	0x128
+#define MCHP_SAF_PROT_RG11_LIMIT_OFS	0x138
+#define MCHP_SAF_PROT_RG12_LIMIT_OFS	0x148
+#define MCHP_SAF_PROT_RG13_LIMIT_OFS	0x158
+#define MCHP_SAF_PROT_RG14_LIMIT_OFS	0x168
+#define MCHP_SAF_PROT_RG15_LIMIT_OFS	0x178
+#define MCHP_SAF_PROT_RG16_LIMIT_OFS	0x188
+#define MCHP_SAF_PROT_RG_LIMIT_MASK	0xfffff
+#define MCHP_SAF_PROT_RG_LIMIT_DFLT	0
+
+/* SAF Protection Region Write Bitmap registers */
+#define MCHP_SAF_PROT_RG0_WBM_OFS	0x8c
+#define MCHP_SAF_PROT_RG1_WBM_OFS	0x9c
+#define MCHP_SAF_PROT_RG2_WBM_OFS	0xac
+#define MCHP_SAF_PROT_RG3_WBM_OFS	0xbc
+#define MCHP_SAF_PROT_RG4_WBM_OFS	0xcc
+#define MCHP_SAF_PROT_RG5_WBM_OFS	0xdc
+#define MCHP_SAF_PROT_RG6_WBM_OFS	0xec
+#define MCHP_SAF_PROT_RG7_WBM_OFS	0xfc
+#define MCHP_SAF_PROT_RG8_WBM_OFS	0x10c
+#define MCHP_SAF_PROT_RG9_WBM_OFS	0x11c
+#define MCHP_SAF_PROT_RG10_WBM_OFS	0x12c
+#define MCHP_SAF_PROT_RG11_WBM_OFS	0x13c
+#define MCHP_SAF_PROT_RG12_WBM_OFS	0x14c
+#define MCHP_SAF_PROT_RG13_WBM_OFS	0x15c
+#define MCHP_SAF_PROT_RG14_WBM_OFS	0x16c
+#define MCHP_SAF_PROT_RG15_WBM_OFS	0x17c
+#define MCHP_SAF_PROT_RG16_WBM_OFS	0x18c
+#define MCHP_SAF_PROT_RG_WBM_MASK	0xff
+#define MCHP_SAF_PROT_RG_WBM0		BIT(0)
+#define MCHP_SAF_PROT_RG_WBM1		BIT(1)
+#define MCHP_SAF_PROT_RG_WBM2		BIT(2)
+#define MCHP_SAF_PROT_RG_WBM3		BIT(3)
+#define MCHP_SAF_PROT_RG_WBM4		BIT(4)
+#define MCHP_SAF_PROT_RG_WBM5		BIT(5)
+#define MCHP_SAF_PROT_RG_WBM6		BIT(6)
+#define MCHP_SAF_PROT_RG_WBM7		BIT(7)
+
+/* SAF Protection Region Read Bitmap registers */
+#define MCHP_SAF_PROT_RG0_RBM_OFS	0x90
+#define MCHP_SAF_PROT_RG1_RBM_OFS	0xa0
+#define MCHP_SAF_PROT_RG2_RBM_OFS	0xb0
+#define MCHP_SAF_PROT_RG3_RBM_OFS	0xc0
+#define MCHP_SAF_PROT_RG4_RBM_OFS	0xd0
+#define MCHP_SAF_PROT_RG5_RBM_OFS	0xe0
+#define MCHP_SAF_PROT_RG6_RBM_OFS	0xf0
+#define MCHP_SAF_PROT_RG7_RBM_OFS	0x100
+#define MCHP_SAF_PROT_RG8_RBM_OFS	0x110
+#define MCHP_SAF_PROT_RG9_RBM_OFS	0x120
+#define MCHP_SAF_PROT_RG10_RBM_OFS	0x130
+#define MCHP_SAF_PROT_RG11_RBM_OFS	0x140
+#define MCHP_SAF_PROT_RG12_RBM_OFS	0x150
+#define MCHP_SAF_PROT_RG13_RBM_OFS	0x160
+#define MCHP_SAF_PROT_RG14_RBM_OFS	0x170
+#define MCHP_SAF_PROT_RG15_RBM_OFS	0x180
+#define MCHP_SAF_PROT_RG16_RBM_OFS	0x190
+#define MCHP_SAF_PROT_RG_RBM_MASK	0xff
+#define MCHP_SAF_PROT_RG_RBM0		BIT(0)
+#define MCHP_SAF_PROT_RG_RBM1		BIT(1)
+#define MCHP_SAF_PROT_RG_RBM2		BIT(2)
+#define MCHP_SAF_PROT_RG_RBM3		BIT(3)
+#define MCHP_SAF_PROT_RG_RBM4		BIT(4)
+#define MCHP_SAF_PROT_RG_RBM5		BIT(5)
+#define MCHP_SAF_PROT_RG_RBM6		BIT(6)
+#define MCHP_SAF_PROT_RG_RBM7		BIT(7)
+
+/* SAF Poll Timeout register */
+#define MCHP_SAF_POLL_TMOUT_OFS	0x194
+#define MCHP_SAF_POLL_TMOUT_MASK	0x3ffff
+#define MCHP_SAF_POLL_TMOUT_5S		0x28000
+
+/* SAF Poll Interval register */
+#define MCHP_SAF_POLL_INTRVL_OFS	0x198
+#define MCHP_SAF_POLL_INTRVL_MASK	0xffff
+
+/* SAF Suspend Resume Interval register */
+#define MCHP_SAF_SUS_RSM_INTRVL_OFS	0x19c
+#define MCHP_SAF_SUS_RSM_INTRVL_MASK	0xffff
+
+/* SAF Consecutive Read Timeout register */
+#define MCHP_SAF_CRD_TMOUT_OFS	0x1a0
+#define MCHP_SAF_CRD_TMOUT_MASK	0xfffff
+
+/* SAF Flash CS0/CS1 Configuration Poll2 Mask registers */
+#define MCHP_SAF_FL0_CFG_P2M_OFS	0x1a4
+#define MCHP_SAF_FL1_CFG_P2M_OFS	0x1a6
+#define MCHP_SAF_FL_CFG_P2M_MASK	0xffff
+
+/* SAF Flash Configuration Special Mode register */
+#define MCHP_SAF_FL_CFG_SPM_OFS	0x1a8
+#define MCHP_SAF_FL_CFG_SPM_MASK	0x01
+#define MCHP_SAF_FL_CFG_SPM_DIS_SUSP	BIT(0)
+
+/* SAF Suspend Check Delay register */
+#define MCHP_SAF_SUS_CHK_DLY_OFS	0x1ac
+#define MCHP_SAF_SUS_CHK_DLY_MASK	0xfffff
+
+/* SAF Flash 0/1 Continuous Mode Prefix registers */
+#define MCHP_SAF_FL_CM_PRF_OFS	0x1b0
+#define MCHP_SAF_FL_CM_PRF_MASK	0xffff
+#define MCHP_SAF_FL_CM_PRF_CS_OP_POS	0
+#define MCHP_SAF_FL_CM_PRF_CS_OP_MASK	0xff
+#define MCHP_SAF_FL_CM_PRF_CS_DAT_POS	8
+#define MCHP_SAF_FL_CM_PRF_CS_DAT_MASK	\
+	(0xff << MCHP_SAF_FL_CM_PRF_CS_DAT_POS)
+
+/* SAF DnX Protection Bypass register */
+#define MCHP_SAF_DNX_PROT_BYP_OFS	0x1b4
+#define MCHP_SAF_DNX_PROT_BYP_MASK	0xffffffff
+
+/* SAF Communication Mode */
+#define MCHP_SAF_COMM_MODE_MASK	0x01
+/* Allow pre-fetch from flash devices */
+#define MCHP_SAF_COMM_MODE_PF_EN	BIT(0)
+
+/* SAF TAG numbers[0:0xF] */
+#define MCHP_SAF_TAG_M0T0	0
+#define MCHP_SAF_TAG_M0T1	1
+#define MCHP_SAF_TAG_M1T0	2
+#define MCHP_SAF_TAG_M1T1	3
+#define MCHP_SAF_TAG_M2T0	4
+#define MCHP_SAF_TAG_M2T1	5
+#define MCHP_SAF_TAG_M3T0	6
+#define MCHP_SAF_TAG_M2T2	7
+#define MCHP_SAF_TAG_M6T0	9
+#define MCHP_SAF_TAG_M6T1	0xd
+#define MCHP_SAF_TAG_MAX	0x10
+
+/* SAF Master numbers */
+#define MCHP_SAF_MSTR_CS_INIT	0
+#define MCHP_SAF_MSTR_CPU	1
+#define MCHP_SAF_MSTR_CS_ME	2
+#define MCHP_SAF_MSTR_CS_LAN	3
+#define MCHP_SAF_MSTR_UNUSED4	4
+#define MCHP_SAF_MSTR_EC_FW	5
+#define MCHP_SAF_MSTR_CS_IE	6
+#define MCHP_SAF_MSTR_UNUSED7	7
+#define MCHP_SAF_MSTR_MAX	8
+#define MCHP_SAF_MSTR_ALL	0xff
+
+
+#endif /* ESPI_SAF_H_ */

--- a/mec/mec1501/component/qmspi.h
+++ b/mec/mec1501/component/qmspi.h
@@ -38,11 +38,11 @@
 
 #include "regaccess.h"
 
-#define QMPSPI_HW_VER		3u
+#define QMPSPI_HW_VER	3u
 
-#define MCHP_QMSPI_BASE_ADDR		0x40070000ul
+#define MCHP_QMSPI_BASE_ADDR	0x40070000ul
 
-#define MCHP_QMSPI_MAX_DESCR		16ul
+#define MCHP_QMSPI_MAX_DESCR	16ul
 
 #define MCHP_QMSPI_INPUT_CLOCK_FREQ_HZ	48000000ul
 #define MCHP_QMSPI_MAX_FREQ_KHZ	((MCHP_QMSPI_INPUT_CLOCK_FREQ_HZ) / 1000ul)
@@ -50,6 +50,7 @@
 
 #define MCHP_QMSPI_GIRQ_NUM		18u
 #define MCHP_QMSPI_GIRQ_POS		1u
+#define MCHP_QMSPI_GIRQ_VAL		BIT(MCHP_QMSPI_GIRQ_POS)
 #define MCHP_QMSPI_GIRQ_OFS		(((MCHP_QMSPI0_GIRQ_NUM) - 8) * 20u)
 
 #define MCHP_QMSPI_GIRQ_NVIC_AGGR	10u
@@ -68,13 +69,13 @@
 #define MCHP_QMSPI_GIRQ_EN		(1ul << (MCHP_QMSPI_GIRQ_POS))
 #define MCHP_QMSPI_GIRQ_STS		(1ul << (MCHP_QMSPI_GIRQ_POS))
 
-/* Mode 0: Clock idle = Low. Data changes on falling edge, sample on rising edge */
+/* Mode 0: Clock idle = Low. Data change falling edge, sample rising edge */
 #define MCHP_QMSPI_SPI_MODE0		0ul
-/* Mode 1: Clock idle = Low. Data changes on rising edge, sample on falling edge */
+/* Mode 1: Clock idle = Low. Data change rising edge, sample falling edge */
 #define MCHP_QMSPI_SPI_MODE1		0x06ul
-/* Mode 2: Clock idle = High. Data changes on rising edge, sample on falling edge */
+/* Mode 2: Clock idle = High. Data change rising edge, sample falling edge */
 #define MCHP_QMSPI_SPI_MODE2		0x06ul
-/* Mode 3: Clock idle = High. Data changes on falling edge, sample on rising edge */
+/* Mode 3: Clock idle = High. Data change falling edge, sample rising edge */
 #define MCHP_QMSPI_SPI_MODE3		0x07ul
 
 /* Device ID used in DMA channel Control.DeviceID field */
@@ -99,7 +100,7 @@
 #define MCHP_QMSPI_RX_FIFO_OFS		0x24ul
 #define MCHP_QMSPI_CSTM_OFS		0x28ul
 /* 0 <= n < MCHP_QMSPI_MAX_DESCR */
-#define MCHP_QMSPI_DESCR_OFS(n)		(0x30ul + ((uint32_t)(n) << 2))
+#define MCHP_QMSPI_DESCR_OFS(n)		(0x30ul + ((uint32_t)(n) * 4U))
 #define MCHP_QMSPI_DESC0_OFS		0x30ul
 
 #define MCHP_QMSPI_MODE_ADDR		(MCHP_QMSPI_BASE_ADDR + 0x00)
@@ -118,23 +119,24 @@
 	(MCHP_QMSPI_BASE_ADDR + (0x30 + (((uint32_t)(n) & 0x0Ful) << 2)))
 
 /* Mode Register */
-#define MCHP_QMSPI_M_SRST		0x02ul
-#define MCHP_QMSPI_M_ACTIVATE		0x01ul
+#define MCHP_QMSPI_M_ACTIVATE		BIT(0)
+#define MCHP_QMSPI_M_SRST		BIT(1)
+#define MCHP_QMSPI_M_SAF_DMA_MODE_EN	BIT(2)
 #define MCHP_QMSPI_M_CPOL_POS		8u
-#define MCHP_QMSPI_M_CPOL_CLK_IDLE_LO	(0ul << 8)
-#define MCHP_QMSPI_M_CPOL_CLK_IDLE_HI	(0ul << 8)
+#define MCHP_QMSPI_M_CPOL_CLK_IDLE_LO	0
+#define MCHP_QMSPI_M_CPOL_CLK_IDLE_HI	BIT(8)
 
 #define MCHP_QMSPI_M_CPHA_MOSI_POS	9u
 /* MOSI data changes on first clock edge of clock pulse */
 #define MCHP_QMSPI_M_CPHA_MOSI_CE1	(0ul << 9)
 /* MOSI data changes on second clock edge of clock pulse */
-#define MCHP_QMSPI_M_CPHA_MOSI_CE2	(1ul << 9)
+#define MCHP_QMSPI_M_CPHA_MOSI_CE2	BIT(9)
 
 #define MCHP_QMSPI_M_CPHA_MIS0_POS	10u
 /* MISO data capture on first clock edge of clock pulse */
-#define MCHP_QMSPI_M_CPHA_MISO_CE1	(0ul << 9)
+#define MCHP_QMSPI_M_CPHA_MISO_CE1	0ul
 /* MISO data capture on second clock edge of clock pulse */
-#define MCHP_QMSPI_M_CPHA_MISO_CE2	(1ul << 9)
+#define MCHP_QMSPI_M_CPHA_MISO_CE2	BIT(10)
 
 #define MCHP_QMSPI_M_SIG_POS		8u
 #define MCHP_QMSPI_M_SIG_MASK0		0x07ul
@@ -143,7 +145,7 @@
 #define MCHP_QMSPI_M_SIG_MODE1_VAL	0x06ul
 #define MCHP_QMSPI_M_SIG_MODE2_VAL	0x01ul
 #define MCHP_QMSPI_M_SIG_MODE3_VAL	0x07ul
-#define MCHP_QMSPI_M_SIG_MODE0		(0x00ul << MCHP_QMSPI_M_SIG_POS)
+#define MCHP_QMSPI_M_SIG_MODE0		0x00ul
 #define MCHP_QMSPI_M_SIG_MODE1		(0x06ul << MCHP_QMSPI_M_SIG_POS)
 #define MCHP_QMSPI_M_SIG_MODE2		(0x01ul << MCHP_QMSPI_M_SIG_POS)
 #define MCHP_QMSPI_M_SIG_MODE3		(0x07ul << MCHP_QMSPI_M_SIG_POS)
@@ -164,60 +166,69 @@
 #define MCHP_QMSPI_C_IFM_1X		0x00ul
 #define MCHP_QMSPI_C_IFM_2X		0x01ul
 #define MCHP_QMSPI_C_IFM_4X		0x02ul
-#define MCHP_QMSPI_C_TX_MASK		(0x03ul << 2)
-#define MCHP_QMSPI_C_TX_DIS		(0x00ul << 2)
-#define MCHP_QMSPI_C_TX_DATA		(0x01ul << 2)
-#define MCHP_QMSPI_C_TX_ZEROS		(0x02ul << 2)
-#define MCHP_QMSPI_C_TX_ONES		(0x03ul << 2)
+#define MCHP_QMSPI_C_TX_POS		2u
+#define MCHP_QMSPI_C_TX_MASK		(0x03ul << MCHP_QMSPI_C_TX_POS)
+#define MCHP_QMSPI_C_TX_DIS		(0x00ul << MCHP_QMSPI_C_TX_POS)
+#define MCHP_QMSPI_C_TX_DATA		(0x01ul << MCHP_QMSPI_C_TX_POS)
+#define MCHP_QMSPI_C_TX_ZEROS		(0x02ul << MCHP_QMSPI_C_TX_POS)
+#define MCHP_QMSPI_C_TX_ONES		(0x03ul << MCHP_QMSPI_C_TX_POS)
 #define MCHP_QMSPI_C_TX_DMA_POS		4u
-#define MCHP_QMSPI_C_TX_DMA_MASK	(0x03ul << 4)
-#define MCHP_QMSPI_C_TX_DMA_DIS		(0x00ul << 4)
-#define MCHP_QMSPI_C_TX_DMA_1B		(0x01ul << 4)
-#define MCHP_QMSPI_C_TX_DMA_2B		(0x02ul << 4)
-#define MCHP_QMSPI_C_TX_DMA_4B		(0x03ul << 4)
-#define MCHP_QMSPI_C_RX_DIS		(0ul << 6)
-#define MCHP_QMSPI_C_RX_EN		(1ul << 6)
+#define MCHP_QMSPI_C_TX_DMA_MASK	(0x03ul << MCHP_QMSPI_C_TX_DMA_POS)
+#define MCHP_QMSPI_C_TX_DMA_DIS		(0x00ul << MCHP_QMSPI_C_TX_DMA_POS)
+#define MCHP_QMSPI_C_TX_DMA_1B		(0x01ul << MCHP_QMSPI_C_TX_DMA_POS)
+#define MCHP_QMSPI_C_TX_DMA_2B		(0x02ul << MCHP_QMSPI_C_TX_DMA_POS)
+#define MCHP_QMSPI_C_TX_DMA_4B		(0x03ul << MCHP_QMSPI_C_TX_DMA_POS)
+#define MCHP_QMSPI_C_RX_POS		6u
+#define MCHP_QMSPI_C_RX_DIS		(0ul << MCHP_QMSPI_C_RX_POS)
+#define MCHP_QMSPI_C_RX_EN		(1ul << MCHP_QMSPI_C_RX_POS)
 #define MCHP_QMSPI_C_RX_DMA_POS		7u
-#define MCHP_QMSPI_C_RX_DMA_MASK	(0x03ul << 7)
-#define MCHP_QMSPI_C_RX_DMA_DIS		(0x00ul << 7)
-#define MCHP_QMSPI_C_RX_DMA_1B		(0x01ul << 7)
-#define MCHP_QMSPI_C_RX_DMA_2B		(0x02ul << 7)
-#define MCHP_QMSPI_C_RX_DMA_4B		(0x03ul << 7)
-#define MCHP_QMSPI_C_NO_CLOSE		(0ul << 9)
-#define MCHP_QMSPI_C_CLOSE		(1ul << 9)
+#define MCHP_QMSPI_C_RX_DMA_MASK	(0x03ul << MCHP_QMSPI_C_RX_DMA_POS)
+#define MCHP_QMSPI_C_RX_DMA_DIS		(0x00ul << MCHP_QMSPI_C_RX_DMA_POS)
+#define MCHP_QMSPI_C_RX_DMA_1B		(0x01ul << MCHP_QMSPI_C_RX_DMA_POS)
+#define MCHP_QMSPI_C_RX_DMA_2B		(0x02ul << MCHP_QMSPI_C_RX_DMA_POS)
+#define MCHP_QMSPI_C_RX_DMA_4B		(0x03ul << MCHP_QMSPI_C_RX_DMA_POS)
+#define MCHP_QMSPI_C_CLOSE_POS		9u
+#define MCHP_QMSPI_C_NO_CLOSE		(0ul << MCHP_QMSPI_C_CLOSE_POS)
+#define MCHP_QMSPI_C_CLOSE		(1ul << MCHP_QMSPI_C_CLOSE_POS)
 #define MCHP_QMSPI_C_XFR_UNITS_POS	10u
-#define MCHP_QMSPI_C_XFR_UNITS_MASK	(0x03ul << 10)
-#define MCHP_QMSPI_C_XFR_UNITS_BITS	(0x00ul << 10)
-#define MCHP_QMSPI_C_XFR_UNITS_1	(0x01ul << 10)
-#define MCHP_QMSPI_C_XFR_UNITS_4	(0x02ul << 10)
-#define MCHP_QMSPI_C_XFR_UNITS_16	(0x03ul << 10)
+#define MCHP_QMSPI_C_XFR_UNITS_MASK	(0x03ul << MCHP_QMSPI_C_XFR_UNITS_POS)
+#define MCHP_QMSPI_C_XFR_UNITS_BITS	(0x00ul << MCHP_QMSPI_C_XFR_UNITS_POS)
+#define MCHP_QMSPI_C_XFR_UNITS_1	(0x01ul << MCHP_QMSPI_C_XFR_UNITS_POS)
+#define MCHP_QMSPI_C_XFR_UNITS_4	(0x02ul << MCHP_QMSPI_C_XFR_UNITS_POS)
+#define MCHP_QMSPI_C_XFR_UNITS_16	(0x03ul << MCHP_QMSPI_C_XFR_UNITS_POS)
 #define MCHP_QMSPI_C_NEXT_DESCR_POS	12u
 #define MCHP_QMSPI_C_NEXT_DESCR_MASK0	0x0Ful
-#define MCHP_QMSPI_C_NEXT_DESCR_MASK	(0x0Ful << 12)
-#define MCHP_QMSPI_C_DESCR0		(0ul << 12)
-#define MCHP_QMSPI_C_DESCR1		(1ul << 12)
-#define MCHP_QMSPI_C_DESCR2		(2ul << 12)
-#define MCHP_QMSPI_C_DESCR3		(3ul << 12)
-#define MCHP_QMSPI_C_DESCR4		(4ul << 12)
+#define MCHP_QMSPI_C_NEXT_DESCR_MASK	(MCHP_QMSPI_C_NEXT_DESCR_MASK0 << \
+					 MCHP_QMSPI_C_NEXT_DESCR_POS)
+#define MCHP_QMSPI_C_DESCR0		(0ul << MCHP_QMSPI_C_NEXT_DESCR_POS)
+#define MCHP_QMSPI_C_DESCR1		(1ul << MCHP_QMSPI_C_NEXT_DESCR_POS)
+#define MCHP_QMSPI_C_DESCR2		(2ul << MCHP_QMSPI_C_NEXT_DESCR_POS)
+#define MCHP_QMSPI_C_DESCR3		(3ul << MCHP_QMSPI_C_NEXT_DESCR_POS)
+#define MCHP_QMSPI_C_DESCR4		(4ul << MCHP_QMSPI_C_NEXT_DESCR_POS)
 /* Control register start descriptor field */
-#define MCHP_QMSPI_C_DESCR(n) \
-	(((uint32_t)(n) & 0x0f) << 12)
+#define MCHP_QMSPI_C_DESCR(n) (((uint32_t)(n) & \
+				MCHP_QMSPI_C_NEXT_DESCR_MASK0) << \
+				MCHP_QMSPI_C_NEXT_DESCR_POS)
 /* Descriptor registers next descriptor field */
-#define MCHP_QMSPI_C_NEXT_DESCR(n) \
-	(((uint32_t)(n) & 0x0f) << 12)
+#define MCHP_QMSPI_C_NEXT_DESCR(n) (((uint32_t)(n) & \
+				     MCHP_QMSPI_C_NEXT_DESCR_MASK0) << \
+				     MCHP_QMSPI_C_NEXT_DESCR_POS)
 /* Control register descriptor mode enable */
 #define MCHP_QMSPI_C_DESCR_EN_POS	16u
-#define MCHP_QMSPI_C_DESCR_EN		(1ul << 16)
+#define MCHP_QMSPI_C_DESCR_EN		(1ul << MCHP_QMSPI_C_DESCR_EN_POS)
 /* Descriptor registers last descriptor flag */
-#define MCHP_QMSPI_C_DESCR_LAST		(1ul << 16)
+#define MCHP_QMSPI_C_DESCR_LAST		(1ul << MCHP_QMSPI_C_DESCR_EN_POS)
 #define MCHP_QMSPI_C_MAX_UNITS		0x7FFFul
 #define MCHP_QMSPI_C_MAX_UNITS_MASK	0x7FFFul
 #define MCHP_QMSPI_C_XFR_NUNITS_POS	17u
 #define MCHP_QMSPI_C_XFR_NUNITS_MASK0	0x7FFFul
-#define MCHP_QMSPI_C_XFR_NUNITS_MASK	(0x7FFFul << 17)
-#define MCHP_QMSPI_C_XFR_NUNITS(n)	((uint32_t)(n) << 17)
-#define MCHP_QMSPI_C_XFR_NUNITS_GET(n) \
-	(((uint32_t)(n) >> 17) & MCHP_QMSPI_C_MAX_UNITS_MASK)
+#define MCHP_QMSPI_C_XFR_NUNITS_MASK	(MCHP_QMSPI_C_XFR_NUNITS_MASK0 << \
+					 MCHP_QMSPI_C_XFR_NUNITS_POS)
+#define MCHP_QMSPI_C_XFR_NUNITS(n) ((uint32_t)(n) << \
+				    MCHP_QMSPI_C_XFR_NUNITS_POS)
+#define MCHP_QMSPI_C_XFR_NUNITS_GET(n) (((uint32_t)(n) >> \
+					 MCHP_QMSPI_C_XFR_NUNITS_POS) & \
+					 MCHP_QMSPI_C_MAX_UNITS_MASK)
 
 /* Exe */
 #define MCHP_QMSPI_EXE_START		0x01ul
@@ -226,28 +237,37 @@
 
 /* Interface Control */
 #define MCHP_QMSPI_IFC_DFLT		0x00ul
+#define MCHP_QMSPI_IFC_WP_OUT_HI	BIT(0)
+#define MCHP_QMSPI_IFC_WP_OUT_EN	BIT(1)
+#define MCHP_QMSPI_IFC_HOLD_OUT_HI	BIT(2)
+#define MCHP_QMSPI_IFC_HOLD_OUT_EN	BIT(3)
+#define MCHP_QMSPI_IFC_PD_ON_NS		BIT(4)
+#define MCHP_QMSPI_IFC_PU_ON_NS		BIT(5)
+#define MCHP_QMSPI_IFC_PD_ON_ND		BIT(6)
+#define MCHP_QMSPI_IFC_PU_ON_ND		BIT(7)
 
 /* Status Register */
 #define MCHP_QMSPI_STS_REG_MASK		0x0F01FF1Ful
 #define MCHP_QMSPI_STS_RO_MASK		0x0F013300ul
 #define MCHP_QMSPI_STS_RW1C_MASK	0x0000CC1Ful
-#define MCHP_QMSPI_STS_DONE		(1ul << 0)
-#define MCHP_QMSPI_STS_DMA_DONE		(1ul << 1)
-#define MCHP_QMSPI_STS_TXB_ERR		(1ul << 2)
-#define MCHP_QMSPI_STS_RXB_ERR		(1ul << 3)
-#define MCHP_QMSPI_STS_PROG_ERR		(1ul << 4)
-#define MCHP_QMSPI_STS_TXBF_RO		(1ul << 8)
-#define MCHP_QMSPI_STS_TXBE_RO		(1ul << 9)
-#define MCHP_QMSPI_STS_TXBR		(1ul << 10)
-#define MCHP_QMSPI_STS_TXBS		(1ul << 11)
-#define MCHP_QMSPI_STS_RXBF_RO		(1ul << 12)
-#define MCHP_QMSPI_STS_RXBE_RO		(1ul << 13)
-#define MCHP_QMSPI_STS_RXBR		(1ul << 14)
-#define MCHP_QMSPI_STS_RXBS		(1ul << 15)
-#define MCHP_QMSPI_STS_ACTIVE_RO	(1ul << 16)
+#define MCHP_QMSPI_STS_DONE		BIT(0)
+#define MCHP_QMSPI_STS_DMA_DONE		BIT(1)
+#define MCHP_QMSPI_STS_TXB_ERR		BIT(2)
+#define MCHP_QMSPI_STS_RXB_ERR		BIT(3)
+#define MCHP_QMSPI_STS_PROG_ERR		BIT(4)
+#define MCHP_QMSPI_STS_TXBF_RO		BIT(8)
+#define MCHP_QMSPI_STS_TXBE_RO		BIT(9)
+#define MCHP_QMSPI_STS_TXBR		BIT(10)
+#define MCHP_QMSPI_STS_TXBS		BIT(11)
+#define MCHP_QMSPI_STS_RXBF_RO		BIT(12)
+#define MCHP_QMSPI_STS_RXBE_RO		BIT(13)
+#define MCHP_QMSPI_STS_RXBR		BIT(14)
+#define MCHP_QMSPI_STS_RXBS		BIT(15)
+#define MCHP_QMSPI_STS_ACTIVE_RO	BIT(16)
 #define MCHP_QMSPI_STS_CD_POS		24u
 #define MCHP_QMSPI_STS_CD_MASK0		0x0Ful
-#define MCHP_QMSPI_STS_CD_MASK		(0x0Ful << 24)
+#define MCHP_QMSPI_STS_CD_MASK		(MCHP_QMSPI_STS_CD_MASK0 << \
+					 MCHP_QMSPI_STS_CD_POS)
 
 /* Buffer Count Status (RO) */
 #define MCHP_QMSPI_TX_BUF_CNT_STS_POS	0u
@@ -256,33 +276,36 @@
 #define MCHP_QMSPI_RX_BUF_CNT_STS_MASK	0xffff0000ul
 
 /* Interrupt Enable Register */
-#define MCHP_QMSPI_IEN_XFR_DONE		(1ul << 0)
-#define MCHP_QMSPI_IEN_DMA_DONE		(1ul << 1)
-#define MCHP_QMSPI_IEN_TXB_ERR		(1ul << 2)
-#define MCHP_QMSPI_IEN_RXB_ERR		(1ul << 3)
-#define MCHP_QMSPI_IEN_PROG_ERR		(1ul << 4)
-#define MCHP_QMSPI_IEN_TXB_FULL		(1ul << 8)
-#define MCHP_QMSPI_IEN_TXB_EMPTY	(1ul << 9)
-#define MCHP_QMSPI_IEN_TXB_REQ		(1ul << 10)
-#define MCHP_QMSPI_IEN_RXB_FULL		(1ul << 12)
-#define MCHP_QMSPI_IEN_RXB_EMPTY	(1ul << 13)
-#define MCHP_QMSPI_IEN_RXB_REQ		(1ul << 14)
+#define MCHP_QMSPI_IEN_XFR_DONE		BIT(0)
+#define MCHP_QMSPI_IEN_DMA_DONE		BIT(1)
+#define MCHP_QMSPI_IEN_TXB_ERR		BIT(2)
+#define MCHP_QMSPI_IEN_RXB_ERR		BIT(3)
+#define MCHP_QMSPI_IEN_PROG_ERR		BIT(4)
+#define MCHP_QMSPI_IEN_TXB_FULL		BIT(8)
+#define MCHP_QMSPI_IEN_TXB_EMPTY	BIT(9)
+#define MCHP_QMSPI_IEN_TXB_REQ		BIT(10)
+#define MCHP_QMSPI_IEN_RXB_FULL		BIT(12)
+#define MCHP_QMSPI_IEN_RXB_EMPTY	BIT(13)
+#define MCHP_QMSPI_IEN_RXB_REQ		BIT(14)
 
 /* Buffer Count Trigger (RW) */
-#define MCHP_QMSPI_TX_BUF_CNT_TRIG_POS	0u
-#define MCHP_QMSPI_RX_BUF_CNT_TRIG_POS	16u
+#define MCHP_QMSPI_TX_BUF_CNT_TRIG_POS 0u
+#define MCHP_QMSPI_RX_BUF_CNT_TRIG_POS 16u
 
 /* Chip Select Timing (RW) */
-#define MCHP_QMSPI_CSTM_MASK			0xFF0F0F0Ful
-#define MCHP_QMSPI_CSTM_DFLT			0x06060406ul
-#define MCHP_QMSPI_DLY_CS_ON_CK_STR_POS		0u
-#define MCHP_QMSPI_DLY_CS_ON_CK_STR_MASK	0x0Ful
-#define MCHP_QMSPI_DLY_CK_STP_CS_OFF_POS	8u
-#define MCHP_QMSPI_DLY_CK_STP_CS_OFF_MASK	(0x0Ful << 8)
-#define MCHP_QMSPI_DLY_LST_DAT_HLD_POS		16u
-#define MCHP_QMSPI_DLY_LST_DAT_HLD_MASK		(0x0Ful << 16)
-#define MCHP_QMSPI_DLY_CS_OFF_CS_ON_POS		24u
-#define MCHP_QMSPI_DLY_CS_OFF_CS_ON_MASK	(0x0Ful << 24)
+#define MCHP_QMSPI_CSTM_MASK 0xFF0F0F0Ful
+#define MCHP_QMSPI_CSTM_DFLT 0x06060406ul
+#define MCHP_QMSPI_DLY_CS_ON_CK_STR_POS	0u
+#define MCHP_QMSPI_DLY_CS_ON_CK_STR_MASK 0x0Ful
+#define MCHP_QMSPI_DLY_CK_STP_CS_OFF_POS 8u
+#define MCHP_QMSPI_DLY_CK_STP_CS_OFF_MASK (0x0Ful << \
+					   MCHP_QMSPI_DLY_CK_STP_CS_OFF_POS)
+#define MCHP_QMSPI_DLY_LST_DAT_HLD_POS 16u
+#define MCHP_QMSPI_DLY_LST_DAT_HLD_MASK	(0x0Ful << \
+					 MCHP_QMSPI_DLY_LST_DAT_HLD_POS)
+#define MCHP_QMSPI_DLY_CS_OFF_CS_ON_POS	24u
+#define MCHP_QMSPI_DLY_CS_OFF_CS_ON_MASK (0x0Ful << \
+					  MCHP_QMSPI_DLY_CS_OFF_CS_ON_POS)
 
 #define MCHP_QMSPI_PORT_MAX_IO_PINS	4u
 #define MCHP_QMSPI_PORT_MAX_CS		2u
@@ -291,8 +314,8 @@
  * CS#, CLK, IO0(MOSI), IO1(MISO)
  * do not connect IO2(WP#) or IO3(HOLD#) to MCHP_QMSPI.
  */
-#define MCHP_QMSPI_PORT_MASK_FULL_DUPLEX	0x0Ful
-#define MCHP_QMSPI_PORT_MASK_DUAL		0x0Ful
+#define MCHP_QMSPI_PORT_MASK_FULL_DUPLEX 0x0Ful
+#define MCHP_QMSPI_PORT_MASK_DUAL 0x0Ful
 
 #define MCHP_QMSPI_PIN_IO0_POS	0u
 #define MCHP_QMSPI_PIN_IO1_POS	1u
@@ -319,84 +342,77 @@
 #define MCHP_QMSPI_MODE_FDIV()		REG16(MCHP_QMSPI_MODE_ADDR + 2ul)
 
 /* Control register */
-#define MCHP_QMSPI_CTRL()	REG32(MCHP_QMSPI_CTRL_ADDR)
+#define MCHP_QMSPI_CTRL() REG32(MCHP_QMSPI_CTRL_ADDR)
 
 /* Execute register */
-#define MCHP_QMSPI_EXE()	REG8(MCHP_QMSPI_EXE_ADDR)
+#define MCHP_QMSPI_EXE() REG8(MCHP_QMSPI_EXE_ADDR)
 
 /* Interface Control register */
-#define MCHP_QMSPI_IFC()	REG8(MCHP_QMSPI_IFC_ADDR)
+#define MCHP_QMSPI_IFC() REG8(MCHP_QMSPI_IFC_ADDR)
 
 /* Status register */
-#define MCHP_QMSPI_STS()	REG32(MCHP_QMSPI_STS_ADDR)
+#define MCHP_QMSPI_STS() REG32(MCHP_QMSPI_STS_ADDR)
 
 /* Buffer Count Status register (read-only) */
-#define MCHP_QMSPI_BCNT_STS()		REG32(MCHP_QMSPI_BUFCNT_STS_ADDR)
+#define MCHP_QMSPI_BCNT_STS() REG32(MCHP_QMSPI_BUFCNT_STS_ADDR)
 /* b[15:0] = TX buffer count */
-#define MCHP_QMSPI_BCNT_TX_STS()	REG16(MCHP_QMSPI_BUFCNT_STS_ADDR)
+#define MCHP_QMSPI_BCNT_TX_STS() REG16(MCHP_QMSPI_BUFCNT_STS_ADDR)
 /* b[31:15] = RX buffer count */
-#define MCHP_QMSPI_BCNT_RX_STS()	REG16(MCHP_QMSPI_BUFCNT_STS_ADDR + 2ul)
+#define MCHP_QMSPI_BCNT_RX_STS() REG16(MCHP_QMSPI_BUFCNT_STS_ADDR + 2ul)
 
 /* Interrupt Enable register */
-#define MCHP_QMSPI_IEN()	REG32(MCHP_QMSPI_IEN_ADDR)
+#define MCHP_QMSPI_IEN() REG32(MCHP_QMSPI_IEN_ADDR)
 
 /* TX FIFO write-only */
-#define MCHP_QMSPI_TXB_32()	REG32(MCHP_QMSPI_TXB_ADDR)
-#define MCHP_QMSPI_TXB_16()	REG16(MCHP_QMSPI_TXB_ADDR)
-#define MCHP_QMSPI_TXB_8()	REG8(MCHP_QMSPI_TXB_ADDR)
+#define MCHP_QMSPI_TXB_32() REG32(MCHP_QMSPI_TXB_ADDR)
+#define MCHP_QMSPI_TXB_16() REG16(MCHP_QMSPI_TXB_ADDR)
+#define MCHP_QMSPI_TXB_8() REG8(MCHP_QMSPI_TXB_ADDR)
 
 /* RX FIFO read-only */
-#define MCHP_QMSPI_RXB_32()	REG32(MCHP_QMSPI_RXB_ADDR)
-#define MCHP_QMSPI_RXB_16()	REG16(MCHP_QMSPI_RXB_ADDR)
-#define MCHP_QMSPI_RXB_8()	REG8(MCHP_QMSPI_RXB_ADDR)
+#define MCHP_QMSPI_RXB_32() REG32(MCHP_QMSPI_RXB_ADDR)
+#define MCHP_QMSPI_RXB_16() REG16(MCHP_QMSPI_RXB_ADDR)
+#define MCHP_QMSPI_RXB_8() REG8(MCHP_QMSPI_RXB_ADDR)
 
 /*
  * Descriptor registers
  * 0 <= id < MCHP_QMSPI_MAX_DESCR
  */
-#define MCHP_QMSPI_DESCR(id)	REG32(MCHP_QMSPI_DESCR_ADDR(id))
+#define MCHP_QMSPI_DESCR(id) REG32(MCHP_QMSPI_DESCR_ADDR(id))
 
 #define MCHP_QMSPI_DESCR_NUNITS(id, nu) MCHP_QMSPI_DESCR(id) = \
 	((MCHP_QMSPI_DESCR(id) & ~(MCHP_QMSPI_C_XFR_NUNITS_MASK)) +\
 	(((uint32_t)nu & MCHP_QMSPI_C_XFR_NUNITS_MASK0) \
 		<< MCHP_QMSPI_C_XFR_NUNITS_POS))
 
-/* =========================================================================*/
-/* ================	       QMSPI			   ================ */
-/* =========================================================================*/
-
 /**
-  * @brief Quad Master SPI (QMSPI)
+  * @brief Quad Master SPI (QMSPI) registers
+  * MODE (@ 0x0000) Mode: frequency, chip select, signal sampling
+  * CTRL (@ 0x0004) Control
+  * EXE (@ 0x0008) Execute, write-only
+  * IFCTRL (@ 0x000C) Interface control
+  * STS (@ 0x0010) Status, RW/1C and RO
+  * BCNT_STS (@ 0x0014) Buffer Count Status, RO
+  * IEN (@ 0x0018) Interrupt Enable
+  * BCNT_TRIG (@ 0x001C) Buffer Count Trigger
+  * TX_FIFO (@ 0x0020) Transmit FIFO
+  * RX_FIFO (@ 0x0024) Receive FIFO
+  * CSTM (@ 0x0028) Chip select timing
+  * DESCR[] (@ 0x0030 - 0x006F descriptors)
   */
 typedef struct qmspi_regs {
-	__IOM uint32_t MODE; /*!< (@ 0x0000) QMSPI Mode */
-	__IOM uint32_t CTRL; /*!< (@ 0x0004) QMSPI Control */
-	__IOM uint32_t EXE; /*!< (@ 0x0008) QMSPI Execute */
-	__IOM uint32_t IFCTRL; /*!< (@ 0x000C) QMSPI Interface control */
-	__IOM uint32_t STS; /*!< (@ 0x0010) QMSPI Status */
-	__IOM uint32_t BCNT_STS; /*!< (@ 0x0014) QMSPI Buffer Count Status (RO) */
-	__IOM uint32_t IEN; /*!< (@ 0x0018) QMSPI Interrupt Enable */
-	__IOM uint32_t BCNT_TRIG; /*!< (@ 0x001C) QMSPI Buffer Count Trigger */
-	__IOM uint32_t TX_FIFO; /*!< (@ 0x0020) QMSPI TX FIFO */
-	__IOM uint32_t RX_FIFO; /*!< (@ 0x0024) QMSPI RX FIFO */
-	__IOM uint32_t CSTM; /*!< (@ 0x0028) QMSPI Chip select timing */
+	__IOM uint32_t MODE;
+	__IOM uint32_t CTRL;
+	__IOM uint32_t EXE;
+	__IOM uint32_t IFCTRL;
+	__IOM uint32_t STS;
+	__IOM uint32_t BCNT_STS;
+	__IOM uint32_t IEN;
+	__IOM uint32_t BCNT_TRIG;
+	__IOM uint32_t TX_FIFO;
+	__IOM uint32_t RX_FIFO;
+	__IOM uint32_t CSTM;
 	uint8_t RSVD1[4];
-	__IOM uint32_t DESCR0; /*!< (@ 0x0030) QMSPI Descriptor 0 */
-	__IOM uint32_t DESCR1; /*!< (@ 0x0034) QMSPI Descriptor 1 */
-	__IOM uint32_t DESCR2; /*!< (@ 0x0038) QMSPI Descriptor 2 */
-	__IOM uint32_t DESCR3; /*!< (@ 0x003C) QMSPI Descriptor 3 */
-	__IOM uint32_t DESCR4; /*!< (@ 0x0040) QMSPI Descriptor 4 */
-	__IOM uint32_t DESCR5; /*!< (@ 0x0044) QMSPI Descriptor 5 */
-	__IOM uint32_t DESCR6; /*!< (@ 0x0048) QMSPI Descriptor 6 */
-	__IOM uint32_t DESCR7; /*!< (@ 0x004C) QMSPI Descriptor 7 */
-	__IOM uint32_t DESCR8; /*!< (@ 0x0050) QMSPI Descriptor 8 */
-	__IOM uint32_t DESCR9; /*!< (@ 0x0054) QMSPI Descriptor 9 */
-	__IOM uint32_t DESCR10; /*!< (@ 0x0058) QMSPI Descriptor 10 */
-	__IOM uint32_t DESCR11; /*!< (@ 0x005C) QMSPI Descriptor 11 */
-	__IOM uint32_t DESCR12; /*!< (@ 0x0060) QMSPI Descriptor 12 */
-	__IOM uint32_t DESCR13; /*!< (@ 0x0064) QMSPI Descriptor 13 */
-	__IOM uint32_t DESCR14; /*!< (@ 0x0068) QMSPI Descriptor 14 */
-	__IOM uint32_t DESCR15; /*!< (@ 0x006C) QMSPI Descriptor 15 */
+	__IOM uint32_t DESCR[MCHP_QMSPI_MAX_DESCR];
 } QMSPI_Type;
 
 #endif				/* #ifndef _QMSPI_H */


### PR DESCRIPTION
Add Microchip MEC15xx eSPI SAF header and SAF changes
in other affected hardware headers: espi_io and qmspi.

Signed-off-by: Scott Worley <scott.worley@microchip.com>