### PR TITLE
CMakeLists: use MEC15XX for the series option

### DIFF
--- a/mec/CMakeLists.txt
+++ b/mec/CMakeLists.txt
@@ -4,7 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC1701X .)
-
-zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC1501X common)
-zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC1501X mec1501)
+zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC15XX common)
+zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC15XX mec1501)


### PR DESCRIPTION
Rename the SoC series option to MEC15XX to align with the new hwmv2 config name, drop the 1701x option which had no references anyway.