### PR TITLE
hal: microchip: mec5: Fix bugs in EC subsystem debug enable

### DIFF
--- a/mec5/drivers/mec_ecs.c
+++ b/mec5/drivers/mec_ecs.c
@@ -84,15 +84,18 @@ void mec_hal_ecs_debug_port(enum mec_debug_mode mode)
         break;
     case MEC_DEBUG_MODE_JTAG:
         msk = MEC_ECS_DBG_CTRL_CFG_Msk;
-        val = MEC_BIT(MEC_ECS_DBG_CTRL_EN_Pos) | (uint32_t)MEC_ECS_DBG_CTRL_CFG_JTAG;
+        val = MEC_BIT(MEC_ECS_DBG_CTRL_EN_Pos) |
+            (uint32_t)(MEC_ECS_DBG_CTRL_CFG_JTAG << MEC_ECS_DBG_CTRL_CFG_Pos);
         break;
     case MEC_DEBUG_MODE_SWD:
         msk = MEC_ECS_DBG_CTRL_CFG_Msk;
-        val = MEC_BIT(MEC_ECS_DBG_CTRL_EN_Pos) | (uint32_t)MEC_ECS_DBG_CTRL_CFG_SWD_ONLY;
+        val = MEC_BIT(MEC_ECS_DBG_CTRL_EN_Pos) |
+            (uint32_t)(MEC_ECS_DBG_CTRL_CFG_SWD_ONLY << MEC_ECS_DBG_CTRL_CFG_Pos);
         break;
     case MEC_DEBUG_MODE_SWD_SWV:
         msk = MEC_ECS_DBG_CTRL_CFG_Msk;
-        val = MEC_BIT(MEC_ECS_DBG_CTRL_EN_Pos) | (uint32_t)MEC_ECS_DBG_CTRL_CFG_SWD_SWV;
+        val = MEC_BIT(MEC_ECS_DBG_CTRL_EN_Pos) |
+            (uint32_t)(MEC_ECS_DBG_CTRL_CFG_SWD_SWV << MEC_ECS_DBG_CTRL_CFG_Pos);
         break;
     default:
         return;

--- a/mec5/drivers/mec_ecs_api.h
+++ b/mec5/drivers/mec_ecs_api.h
@@ -52,7 +52,7 @@ uint8_t mec_hal_ecs_peci_vtt_ref_pin_is_enabled(void);
 #define ECS_ETM_PINS_DISABLE 0
 #define ECS_ETM_PINS_ENABLE 1
 
-void mec_ecs_etm_pins(uint8_t enable);
+void mec_hal_ecs_etm_pins(uint8_t enable);
 
 enum mec_debug_mode {
     MEC_DEBUG_MODE_DISABLE = 0,


### PR DESCRIPTION
First, the API to enable/disable ETM debug pins was not named correctly resulting in link error.
Second, the API to set the debug mode was not shifting the enum it used from the chip header file into the correct hardware register field.