### PR TITLE
hal: microchip: pic32cm_pl: add SERCOM I2CM/I2CS ADDR_ADDR mapping macros

### DIFF
--- a/packs/pic32c/pic32cm_pl/common/sercom_pic32cm_pl.h
+++ b/packs/pic32c/pic32cm_pl/common/sercom_pic32cm_pl.h
@@ -32,4 +32,21 @@
  */
 #define UART_GET_BASE_ADDR(regs, is_clock_external) (&((regs)->USART))
 
+/*
+ * The PIC32CM PL pack omits the standard 11-bit ADDR_ADDR macros used by the
+ * SERCOM I2C G1 driver. It only defines SEVENBIT_ADDR_Msk (0x7F), which is
+ * insufficient: the driver writes (addr << 1 | R/W) into the ADDR field, so
+ * any address >= 0x40 sets bit 7 of the shifted value and a 0x7F mask would
+ * strip it. The hardware ADDR field is 11 bits wide on all SERCOM-G1 variants
+ * per the PIC32CM PL family datasheet (section 34.11.10).
+ */
+#define SERCOM_I2CM_ADDR_ADDR_Pos    0
+#define SERCOM_I2CM_ADDR_ADDR_Msk    (0x7FFul << SERCOM_I2CM_ADDR_ADDR_Pos)
+#define SERCOM_I2CM_ADDR_ADDR(value) \
+	(SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
+#define SERCOM_I2CS_ADDR_ADDR_Pos    0
+#define SERCOM_I2CS_ADDR_ADDR_Msk    (0x7FFul << SERCOM_I2CS_ADDR_ADDR_Pos)
+#define SERCOM_I2CS_ADDR_ADDR(value) \
+	(SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
+
 #endif /* MICROCHIP_COMMON_SERCOM_PIC32CM_PL10_H_ */


### PR DESCRIPTION
## Summary

The PIC32CM PL HAL pack omits the standard 11-bit `SERCOM_I2CM_ADDR_ADDR_Msk`
macros used by the SERCOM I2C G1 driver (`i2c_mchp_sercom_g1`). The pack only
defines `SERCOM_I2CM_ADDR_SEVENBIT_ADDR_Msk` with a **0x7F** mask, which is
insufficient.

The driver writes `(7-bit-addr << 1 | R/W)` into the ADDR field. For any
address ≥ 0x40 the shifted value has bit 7 set (e.g. 0x50 → 0xA0). A 0x7F
mask strips that bit, leaving 0x20 and targeting the wrong device. The
hardware ADDR field is 11 bits wide on all SERCOM-G1 variants per the PIC32CM
PL family datasheet (section 34.11.10), matching every other Microchip
SERCOM-G1 pack.

## Changes

Add `SERCOM_I2CM_ADDR_ADDR_{Pos,Msk,()}` and `SERCOM_I2CS_ADDR_ADDR_{Pos,Msk,()}`
to the existing `packs/pic32c/pic32cm_pl/common/sercom_pic32cm_pl.h` mapping
header (established by #57). The correct mask is **0x7FF** (11-bit).

The corresponding Zephyr PR (zephyrproject-rtos/zephyr#108062) will remove the
driver-side `#ifndef` fallback block and bump `west.yml` to this PR's merge
SHA once it lands.

## Precedent

- hal_microchip #57 — established the `sercom_pic32cm_pl.h` mapping header
- zephyr #104556 — used the mapping approach for SERCOM UART G1 on PIC32CM PL