### PR TITLE
hal: microchip: pic32cm_sg_gc: Add mapping file for UART SERCOM g1 driver

### DIFF
--- a/packs/pic32c/pic32cm_sg_gc/CMakeLists.txt
+++ b/packs/pic32c/pic32cm_sg_gc/CMakeLists.txt
@@ -4,3 +4,4 @@
 #
 
 zephyr_include_directories(${CONFIG_SOC_SERIES}/include)
+zephyr_include_directories(common)

--- a/packs/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.h
+++ b/packs/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file pic32cm_sg_gc.h
+ * @brief Top-level include for PIC32CM_SG_GC family macro mapping.
+ *
+ * This header provides a central place to include macro mapping headers
+ * for the Microchip PIC32CM_SG_GC family. Use it to include headers that map
+ * device-specific register and bitfield names to generic names for any
+ * required peripheral.
+ *
+ */
+
+#ifndef MICROCHIP_PIC32CM_SG_GC_H_
+#define MICROCHIP_PIC32CM_SG_GC_H_
+
+#include "sercom_pic32cm_sg_gc.h"
+
+#endif /* MICROCHIP_PIC32CM_SG_GC_H_ */

--- a/packs/pic32c/pic32cm_sg_gc/common/sercom_pic32cm_sg_gc.h
+++ b/packs/pic32c/pic32cm_sg_gc/common/sercom_pic32cm_sg_gc.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file sercom_pic32cm_sg_gc.h
+ * @brief Generic SERCOM USART register macros for PIC32CM_SG_GC family.
+ *
+ * This file provides macros to abstract register and bitfield access for the
+ * SERCOM USART peripheral on the Microchip PIC32CM_SG_GC family of devices.
+ * These macros are intended for use in the SERCOM UART G1 driver.
+ *
+ */
+
+#ifndef MICROCHIP_COMMON_SERCOM_PIC32CM_SG_GC_H_
+#define MICROCHIP_COMMON_SERCOM_PIC32CM_SG_GC_H_
+
+/**
+ * @brief Get the base address of the USART register block.
+ *
+ * This macro returns the base address of the USART registers for the given
+ * SERCOM instance. The @p is_clock_external parameter is included for
+ * compatibility with unified driver code, but is not used for this device
+ * family.
+ *
+ * @param regs Pointer to the SERCOM register structure.
+ * @param is_clock_external Boolean indicating if the clock is external (not
+ * used).
+ * @return Pointer to the USART register block.
+ */
+#define UART_GET_BASE_ADDR(regs, is_clock_external) (&((regs)->USART))
+
+/*SERCOM_USART_CTRLA*/
+#define SERCOM_USART_CTRLA_FORM_USART_FRAME_WITH_PARITY                        \
+  SERCOM_USART_CTRLA_FORM_USARTP
+#define SERCOM_USART_CTRLA_FORM_USART_FRAME_NO_PARITY                          \
+  SERCOM_USART_CTRLA_FORM_USARTP
+#define SERCOM_USART_CTRLA_MODE_USART_EXT SERCOM_USART_CTRLA_MODE_EXTCLK
+#define SERCOM_USART_CTRLA_MODE_USART_INT SERCOM_USART_CTRLA_MODE_INTCLK
+
+/*SERCOM_USART_CTRLB*/
+#define SERCOM_USART_CTRLB_CHSIZE_5_BIT SERCOM_USART_CTRLB_CHSIZE_5BITS
+#define SERCOM_USART_CTRLB_CHSIZE_6_BIT SERCOM_USART_CTRLB_CHSIZE_6BITS
+#define SERCOM_USART_CTRLB_CHSIZE_7_BIT SERCOM_USART_CTRLB_CHSIZE_7BITS
+#define SERCOM_USART_CTRLB_CHSIZE_8_BIT SERCOM_USART_CTRLB_CHSIZE_8BITS
+#define SERCOM_USART_CTRLB_CHSIZE_9_BIT SERCOM_USART_CTRLB_CHSIZE_9BITS
+
+#endif /* MICROCHIP_COMMON_SERCOM_PIC32CM_SG_GC_H_ */


### PR DESCRIPTION
- Added mapping files to declare common macro name definitions for pic32cm_sg_gc to be used in sercom uart g1 driver.