### PR TITLE
hal: microchip: pic32c: Update peripheral definition for pic32cxsg

### DIFF
--- a/include/dt-bindings/pic32c/pic32cx_sg/common/mchp_pinctrl_pinmux_pic32c.h
+++ b/include/dt-bindings/pic32c/pic32cx_sg/common/mchp_pinctrl_pinmux_pic32c.h
@@ -28,6 +28,7 @@
 #define MCHP_PINMUX_PERIPH_i 8U
 #define MCHP_PINMUX_PERIPH_j 9U
 #define MCHP_PINMUX_PERIPH_k 10U
+#define MCHP_PINMUX_PERIPH_l 11U
 
 /** Extra */
 #define MCHP_PINMUX_PERIPH_x 0U


### PR DESCRIPTION
Updated the peripheral definition in pincontrol parsing file.